### PR TITLE
#69: Remove the build trigger on push event

### DIFF
--- a/.github/workflows/build-react-app.yml
+++ b/.github/workflows/build-react-app.yml
@@ -4,8 +4,6 @@
 name: Build React App
 
 on:
-  push:
-    branches: ["master", "release/*"]
   pull_request:
     branches: ["master", "release/*"]
   workflow_dispatch:


### PR DESCRIPTION
# What was the issue
In [a previous PR ](https://github.com/UniversityOfSaskatchewanCMPT371/term-project-2024-team-2/pull/47/files#diff-2d1a6cc0a64281260c3a94149da0c0fc4eb5f24d7adee1cc0bf91d6a6dd4ff71R7-R10)where we set up a basic build pipeline for the project, we put both PR and git push commands as triggers for a build, causing build duplication for PR.

# What was done and why

- Remove git-push command as a trigger for a build

As a dev, we want to eliminate the unnecessary duplication of build process for each pull request.

# How it was tested
No longer running 2 duplicated builds for each node.js version
<img width="953" alt="image" src="https://github.com/UniversityOfSaskatchewanCMPT371/term-project-2024-team-2/assets/66387098/bb98df51-2b15-4359-a5d0-669af12f6d67">


