### PR TITLE
#65 Add a basic dependency review step in CICD pipeline

### DIFF
--- a/.github/workflows/build-react-app.yml
+++ b/.github/workflows/build-react-app.yml
@@ -12,6 +12,9 @@ defaults:
   run:
     working-directory: ./my-webxr-app
 
+permissions:
+  pull-requests: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -34,6 +37,7 @@ jobs:
         uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: moderate
+          comment-summary-in-pr: on-failure
 
       - run: npm run build
       - run: npm test

--- a/.github/workflows/build-react-app.yml
+++ b/.github/workflows/build-react-app.yml
@@ -29,5 +29,11 @@ jobs:
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
       - run: npm ci
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: moderate
+
       - run: npm run build
       - run: npm test

--- a/.github/workflows/build-react-app.yml
+++ b/.github/workflows/build-react-app.yml
@@ -24,20 +24,27 @@ jobs:
         node-version: [16.x, 18.x, 20.x]
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout Branch
+        uses: actions/checkout@v3
+
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
-      - run: npm ci
 
-      - name: Dependency Review
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Review Dependencies
         uses: actions/dependency-review-action@v4
         with:
           fail-on-severity: moderate
           comment-summary-in-pr: on-failure
 
-      - run: npm run build
-      - run: npm test
+      - name: Build Application
+        run: npm run build
+
+      - name: Run Unit Tests
+        run: npm test


### PR DESCRIPTION


# What was the issue
We need to prevent adding dependencies that have vulnerabilities to the repo

# What was done and why
Add a basic dependency review step in CICD pipeline
- The step will fail on any pull requests that introduce vulnerabilities of 'moderate' severity or higher.
- Enable reporting review summary as a comment in the pull request.

# How it was tested
Intentionally add a commit introducing a moderate vulnerability
-> builds failed, PR is blocked from merging and a dependency report was attached to the PR


