### PR TITLE
#123: add write permission on pull request for prod-deployment job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,5 +64,6 @@ jobs:
     needs: build
     permissions:
       checks: write
+      pull-requests: write
     uses: ./.github/workflows/deployment_prod.yml
     secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,7 @@ jobs:
     needs: build
     permissions:
       checks: write
+      pull-requests: write
     uses: ./.github/workflows/deployment_staging.yml
     secrets: inherit
 


### PR DESCRIPTION
# What was the issue
The deployment jobs are missing the write-on-PR permission and therefore, couldn't post a comment with the deployed preview URL on the PR.
<img width="630" alt="image" src="https://github.com/UniversityOfSaskatchewanCMPT371/term-project-2024-team-2/assets/66387098/e0cd1784-a710-4394-a4a0-d30c4d322d10">

# What was done and why
- Add write-on-PR permission for deployment jobs

# How it was tested
- The preview URL is posted below

