### PR TITLE
#143: Remove support for Node.js 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [ 18.x, 20.x ]
 
     steps:
       - name: Checkout Branch


### PR DESCRIPTION
Closes #143.

# What was the issue
Node.js 16 has reached EOL (End of Life) status.

# What was done and why
We are removing support for Node.js 16 from our project. The build step no longer checks compatibility with Node.js 16.

# How it was tested
N/A