### PR TITLE
#144: Clean up npm dependencies

### DIFF
--- a/my-webxr-app/package-lock.json
+++ b/my-webxr-app/package-lock.json
@@ -12,13 +12,11 @@
         "@react-three/fiber": "^8.15.14",
         "@react-three/test-renderer": "^8.2.1",
         "@react-three/xr": "^5.7.1",
-        "@types/log4js": "^2.3.5",
         "idb": "^8.0.0",
         "log4js": "^6.9.1",
         "papaparse": "^5.4.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-three-fiber": "^6.0.13",
         "three": "^0.160.1"
       },
       "devDependencies": {
@@ -3704,15 +3702,6 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
-    },
-    "node_modules/@types/log4js": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@types/log4js/-/log4js-2.3.5.tgz",
-      "integrity": "sha512-SwF8LkSHqHy9A8GQ67NAYJiGl8zzP4Qtx65Wa+IOxDGdMHxKeoQZjg7m2M1erIT6VK0DYHpu2aTbdLkdkuMHjw==",
-      "deprecated": "This is a stub types definition for log4js (https://github.com/nomiddlename/log4js-node). log4js provides its own type definitions, so you don't need @types/log4js installed!",
-      "dependencies": {
-        "log4js": "*"
-      }
     },
     "node_modules/@types/node": {
       "version": "20.11.16",
@@ -8377,25 +8366,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/react-three-fiber": {
-      "version": "6.0.13",
-      "resolved": "https://registry.npmjs.org/react-three-fiber/-/react-three-fiber-6.0.13.tgz",
-      "integrity": "sha512-uShQnkMVLvnzwf3YzY9mnzCnpmLpvTQkc0ycrtwk8fyjXmZt2695tLn3tufPF6uxq06UKJRKJcjCVCMXyUcEPQ==",
-      "deprecated": "react-three-fiber has been deprecated, please use @react-three/fiber from now on",
-      "dependencies": {
-        "@react-three/fiber": "latest"
-      },
-      "peerDependencies": {
-        "react": ">=17.0",
-        "react-dom": ">=17.0",
-        "three": ">=0.126"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
       }
     },
     "node_modules/react-use-measure": {

--- a/my-webxr-app/package.json
+++ b/my-webxr-app/package.json
@@ -15,13 +15,11 @@
     "@react-three/fiber": "^8.15.14",
     "@react-three/test-renderer": "^8.2.1",
     "@react-three/xr": "^5.7.1",
-    "@types/log4js": "^2.3.5",
     "idb": "^8.0.0",
     "log4js": "^6.9.1",
     "papaparse": "^5.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-three-fiber": "^6.0.13",
     "three": "^0.160.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Closes #144.

# What was the issue
We had some deprecated and unnecessary npm dependencies.

# What was done and why
1. Removed duplicate `react-three-fiber` package.
2. Remove unnecessary `@types/log4js` package. `log4js` includes its own types.

# How it was tested
Project build and lint passes.