### PR TITLE
Fixed bug in SingleAxis

### DIFF
--- a/my-webxr-app/src/App.tsx
+++ b/my-webxr-app/src/App.tsx
@@ -5,7 +5,7 @@ import './styles.css';
 import { useEffect } from 'react';
 import { openDB } from 'idb';
 import Floor from './components/Floor';
-import Axis from './components/Axis';
+import GenerateXYZ from './components/GenerateXYZ';
 import { LocalCsvReader, UrlCsvReader } from './components/CsvReader';
 import DataPoint from './components/DataPoint';
 import { PointSelectionProvider } from './contexts/PointSelectionContext';
@@ -37,7 +37,7 @@ export default function App() {
   const storeName = 'CsvData';
 
   // hard coded data. example data would be replaced with PCA results for coordinates
-  // also would like to make a new type for Axis info, allowing for easier use
+  // also would like to make a new type for GenerateXYZ info, allowing for easier use
   const exampleData = [[-1, -1, -1], [2, 3, 0], [4, 3, 0], [1, 1, 1], [3, 2, 2]];
   const datapoint1 = createPosition({
     data: exampleData[0],
@@ -117,7 +117,7 @@ export default function App() {
             <pointLight position={[10, 10, 10]} />
             <Controllers />
 
-            <Axis
+            <GenerateXYZ
               minValue={minNum}
               maxValue={maxNum}
               scaleFactor={scaleFactor}

--- a/my-webxr-app/src/components/Axis.tsx
+++ b/my-webxr-app/src/components/Axis.tsx
@@ -1,4 +1,3 @@
-import { Interactive } from '@react-three/xr';
 import SingleAxis from './SingleAxis';
 
 interface AxisProps {
@@ -26,15 +25,13 @@ export default function Axis({
   radius,
 }: AxisProps) {
   return (
-    <Interactive>
-      {/* adjust position of the whole axis */}
+    <>
       {/* X-axis */}
       <SingleAxis
         startX={startX}
         startY={startY}
         startZ={startZ}
-                    // need this calculation to find full length of axis
-        endX={startX + endPoint}
+        endX={startX + endPoint} // need this calculation to find full length of axis
         endY={startY}
         endZ={startZ}
         radius={radius}
@@ -42,6 +39,7 @@ export default function Axis({
         scaleFactor={scaleFactor}
         minValue={minValue}
         maxValue={maxValue}
+        axis="x"
       />
       {/* Y-axis */}
       <SingleAxis
@@ -56,6 +54,7 @@ export default function Axis({
         scaleFactor={scaleFactor}
         minValue={minValue}
         maxValue={maxValue}
+        axis="y"
       />
       {/* Z-axis */}
       <SingleAxis
@@ -70,7 +69,8 @@ export default function Axis({
         scaleFactor={scaleFactor}
         minValue={minValue}
         maxValue={maxValue}
+        axis="z"
       />
-    </Interactive>
+    </>
   );
 }

--- a/my-webxr-app/src/components/GenerateXYZ.tsx
+++ b/my-webxr-app/src/components/GenerateXYZ.tsx
@@ -13,7 +13,7 @@ interface AxisProps {
 }
 
 // this will create the 3d axis by calling single axis for each axis
-export default function Axis({
+export default function GenerateXYZ({
   minValue,
   maxValue,
   labelOffset,

--- a/my-webxr-app/src/components/SingleAxis.tsx
+++ b/my-webxr-app/src/components/SingleAxis.tsx
@@ -13,6 +13,7 @@ interface SingleAxisProps {
   labelOffset: number;
   minValue: number;
   maxValue: number;
+  axis: string;
 }
 
 // this function will create an axis and call GenerateTicks to put ticks and labels on the axis
@@ -28,6 +29,7 @@ export default function SingleAxis({
   scaleFactor,
   minValue,
   maxValue,
+  axis,
 }: SingleAxisProps) {
   // Calculate the range in positive and negative directions
   const maxNum: number = Math.abs(maxValue);
@@ -100,9 +102,17 @@ export default function SingleAxis({
       {/* Create the axis and color it */}
       <mesh geometry={axisGeometry} material={material} position={position} rotation={rotation} />
       {/* call GenerateTicks for each axis */}
-      {axisTicks.map((label) => GenerateTicks(startX, startY, startZ, labelOffset, scaleFactor, radius, label, labelIncrement, 'x'))}
-      {axisTicks.map((label) => GenerateTicks(startX, startY, startZ, labelOffset, scaleFactor, radius, label, labelIncrement, 'y'))}
-      {axisTicks.map((label) => GenerateTicks(startX, startY, startZ, labelOffset, scaleFactor, radius, label, labelIncrement, 'z'))}
+      {axisTicks.map((label) => GenerateTicks(
+        startX,
+        startY,
+        startZ,
+        labelOffset,
+        scaleFactor,
+        radius,
+        label,
+        labelIncrement,
+        axis,
+      ))}
     </>
   );
 }

--- a/my-webxr-app/tests/3Dpoint-space.test.tsx
+++ b/my-webxr-app/tests/3Dpoint-space.test.tsx
@@ -3,7 +3,7 @@ import { XR } from '@react-three/xr';
 import { Vector3 } from 'three';
 import { PointSelectionProvider } from '../src/contexts/PointSelectionContext';
 import DataPoint from '../src/components/DataPoint';
-import Axis from '../src/components/Axis';
+import GenerateXYZ from '../src/components/GenerateXYZ';
 import createPosition from '../src/components/Positions';
 
 const minNum: number = -10;
@@ -61,7 +61,7 @@ describe("Datapoint's Location is based off of values given ", () => {
       <PointSelectionProvider>
         <XR>
           <DataPoint id={0} marker="circle" color="gray" columnX="John Doe" columnY="cmpt 145" columnZ={97} meshProps={{ position: [1, 2, 3] }} />
-          <Axis
+          <GenerateXYZ
             minValue={minNum}
             maxValue={maxNum}
             scaleFactor={scaleFactor}

--- a/my-webxr-app/tests/Axis.test.tsx
+++ b/my-webxr-app/tests/Axis.test.tsx
@@ -1,14 +1,14 @@
 import ReactThreeTestRenderer from '@react-three/test-renderer';
 import { XR } from '@react-three/xr';
 import { Vector3 } from 'three';
-import Axis from '../src/components/Axis';
+import GenerateXYZ from '../src/components/GenerateXYZ';
 // import SingleAxis from '../src/components/singleAxis';
 
-describe('Axis Tests', () => {
+describe('GenerateXYZ Tests', () => {
   test('Create 3D axis with random values', async () => {
     const renderer = await ReactThreeTestRenderer.create(
       <XR>
-        <Axis
+        <GenerateXYZ
           minValue={0}
           maxValue={10}
           scaleFactor={1}

--- a/my-webxr-app/tests/Axis.test.tsx
+++ b/my-webxr-app/tests/Axis.test.tsx
@@ -21,8 +21,8 @@ describe('Axis Tests', () => {
         />
       </XR>,
     );
-    // check the position vector is correct
-    expect(renderer.scene.children[1].children[0].instance.position).toEqual(
+    // check the position of the axis vector is correct
+    expect(renderer.scene.children[1].instance.position).toEqual(
       new Vector3(0, 0.82, -0.15),
     );
   });


### PR DESCRIPTION
Closes #180 

# What was the issue
Bug in SingleAxis creation, where create ticks was called for each axis, when creating one axis.

# What was done and why
Removed extra calls to generateTicks(). And added an axis parameter to SingleAxis. Now createTicks is only called for the axis that is created with SingleAxis.

# How it was tested
Checked to make sure everything ran correctly.
