### PR TITLE
#204: Darken the UI

### DIFF
--- a/my-webxr-app/src/App.tsx
+++ b/my-webxr-app/src/App.tsx
@@ -111,12 +111,11 @@ export default function App() {
       <PointSelectionProvider>
         <Canvas>
           <XR>
-            <Sky sunPosition={[0, 1, 0]} />
+            <Sky sunPosition={[0.5, 0, 0.5]} />
             <Floor />
             <ambientLight />
             <pointLight position={[10, 10, 10]} />
             <Controllers />
-
             <GenerateXYZ
               minValue={minNum}
               maxValue={maxNum}
@@ -134,7 +133,7 @@ export default function App() {
             <DataPoint
               id={0}
               marker="circle"
-              color="gray"
+              color="yellow"
               columnX="John Doe"
               columnY="cmpt 145"
               columnZ={97}
@@ -143,7 +142,7 @@ export default function App() {
             <DataPoint
               id={1}
               marker="circle"
-              color="gray"
+              color="yellow"
               columnX="Bob Johnson"
               columnY="math 110"
               columnZ={81}
@@ -152,7 +151,7 @@ export default function App() {
             <DataPoint
               id={2}
               marker="circle"
-              color="gray"
+              color="yellow"
               columnX="Bob John"
               columnY="math 116"
               columnZ={87}
@@ -161,7 +160,7 @@ export default function App() {
             <DataPoint
               id={3}
               marker="circle"
-              color="gray"
+              color="yellow"
               columnX="Alice Smith"
               columnY="stat 245"
               columnZ={75}
@@ -170,7 +169,7 @@ export default function App() {
             <DataPoint
               id={4}
               marker="circle"
-              color="gray"
+              color="yellow"
               columnX="Bob Smith"
               columnY="math 115"
               columnZ={85}

--- a/my-webxr-app/src/components/DataPoint.tsx
+++ b/my-webxr-app/src/components/DataPoint.tsx
@@ -56,7 +56,7 @@ export default function DataPoint({
         {/* Low numbers to try to minimize the number of faces we need to render */}
         {/* There will be a LOT of these present in the simulation */}
         <sphereGeometry args={size} />
-        <meshStandardMaterial />
+        <meshStandardMaterial color="yellow" />
       </mesh>
 
       {/* This second mesh is the outline which works by rendering */}
@@ -68,7 +68,7 @@ export default function DataPoint({
       >
         <sphereGeometry args={size} />
         <meshStandardMaterial
-          color={selectedDataPoint?.id === id ? 'blue' : 'aqua'}
+          color={selectedDataPoint?.id === id ? 'darkorange' : 'purple'}
           side={BackSide}
         />
       </mesh>

--- a/my-webxr-app/src/components/DataPointMenu.tsx
+++ b/my-webxr-app/src/components/DataPointMenu.tsx
@@ -18,6 +18,7 @@ export default function DataPointMenu(
   return (
     <Billboard visible={selectedDataPoint != null} {...billboardProps}>
       <Plane args={[1.25, 0.8]}>
+        <meshBasicMaterial color="gray" />
         <Text fontSize={0.075} color="black">
           {`Here are data point # ${selectedDataPoint?.id ?? '-'} properties!\n\n`}
           {`Marker: ${selectedDataPoint?.marker ?? '-'}\n`}

--- a/my-webxr-app/src/components/Floor.tsx
+++ b/my-webxr-app/src/components/Floor.tsx
@@ -3,7 +3,7 @@ export default function Floor() {
   return (
     <mesh rotation={[-Math.PI / 2, 0, 0]}>
       <planeGeometry args={[100, 100]} />
-      <meshStandardMaterial color="#72b2f4" />
+      <meshStandardMaterial color="gray" />
     </mesh>
   );
 }


### PR DESCRIPTION
Closes #204 

# What was the issue
Previous UI made it difficult to see the white beam of the controllers and data points against a light background.

# What was done and why
Changed the colour scheme to use dark colours.
- White to yellow data points
- Blue to dark gray floor
- Bluish white to gradient gray sky
- White to light gray data point info billboard

# How it was tested
On the Firebase web application and through the Oculus to ensure chosen colour shades are visible.


