### PR TITLE
#220 File Name Fix

### DIFF
--- a/my-webxr-app/src/repository/DbRepository.tsx
+++ b/my-webxr-app/src/repository/DbRepository.tsx
@@ -1,7 +1,7 @@
 import Dexie from 'dexie';
 import * as assert from 'assert';
 import { Repository } from './Repository';
-import DataPoint from './DataPoint';
+import RepoDataPoint from './RepoDataPoint';
 import Column, {
   ColumnType, RawColumn, NumericColumn, StatsColumn,
 } from './Column';
@@ -201,7 +201,7 @@ export default class DbRepository extends Dexie implements Repository {
     columnXName: string,
     columnYName: string,
     columnZName: string,
-  ): Promise<Array<DataPoint>> {
+  ): Promise<Array<RepoDataPoint>> {
     // verify the three columns are distinct
     assert.equal(
       (new Set([columnXName, columnYName, columnZName])).size,
@@ -248,8 +248,8 @@ export default class DbRepository extends Dexie implements Repository {
     columnX: Column<RawColumn | NumericColumn>,
     columnY: Column<RawColumn | NumericColumn>,
     columnZ: Column<RawColumn | NumericColumn>,
-  ): Array<DataPoint> {
-    const dataPoints: Array<DataPoint> = [];
+  ): Array<RepoDataPoint> {
+    const dataPoints: Array<RepoDataPoint> = [];
 
     for (let i = 0; i < columnX.values.length; i += 1) {
       // Force type cast to string | number | null.
@@ -261,7 +261,7 @@ export default class DbRepository extends Dexie implements Repository {
 
       // if only qualifying points are requested, add the point only if it has no missing data
       if (!qualifyingPointOnly || (qualifyingPointOnly && !hasMissingData)) {
-        dataPoints.push(new DataPoint(hasMissingData, xValue, yValue, zValue));
+        dataPoints.push(new RepoDataPoint(hasMissingData, xValue, yValue, zValue));
       }
     }
     return dataPoints;

--- a/my-webxr-app/src/repository/RepoDataPoint.tsx
+++ b/my-webxr-app/src/repository/RepoDataPoint.tsx
@@ -1,4 +1,4 @@
-export default class DataPoint {
+export default class RepoDataPoint {
   hasMissingData: boolean;
 
   xValue: number | string | null;

--- a/my-webxr-app/src/repository/Repository.tsx
+++ b/my-webxr-app/src/repository/Repository.tsx
@@ -1,4 +1,4 @@
-import DataPoint from './DataPoint';
+import RepoDataPoint from './RepoDataPoint';
 import Column, {
   ColumnType, NumericColumn, RawColumn, StatsColumn,
 } from './Column';
@@ -9,7 +9,7 @@ export interface Repository {
   getPoints: (qualifyingPointOnly : boolean,
     columnXName: string,
     columnYName: string,
-    columnZName: string) => Promise<Array<DataPoint>>;
+    columnZName: string) => Promise<Array<RepoDataPoint>>;
   addColumn: (column: Column<RawColumn | StatsColumn | NumericColumn>,
     columnType: ColumnType) => Promise<string>;
   getCsvColumnNames: () => Promise<string[]>;

--- a/my-webxr-app/tests/Axis.test.tsx
+++ b/my-webxr-app/tests/Axis.test.tsx
@@ -37,7 +37,7 @@ describe('Axis Tests', () => {
     await waitFor(() => expect(renderer.scene.children !== null).toBeTruthy());
     await waitFor(() => expect(renderer.scene.children[1]).toBeDefined());
     await waitFor(() => expect(renderer.scene.children[1] !== null).toBeTruthy());
-    
+
     // wait for the axes to be rendered
     await waitFor(() => expect(renderer.scene.children[1].children).toBeDefined());
     const axes = renderer.scene.children[1].children;

--- a/my-webxr-app/tests/Axis.test.tsx
+++ b/my-webxr-app/tests/Axis.test.tsx
@@ -34,7 +34,10 @@ describe('Axis Tests', () => {
     const renderer = await ReactThreeTestRenderer.create(<Element />);
     // wait for scene children to be rendered
     await waitFor(() => expect(renderer.scene.children).toBeDefined());
-
+    await waitFor(() => expect(renderer.scene.children !== null).toBeTruthy());
+    await waitFor(() => expect(renderer.scene.children[1]).toBeDefined());
+    await waitFor(() => expect(renderer.scene.children[1] !== null).toBeTruthy());
+    
     // wait for the axes to be rendered
     await waitFor(() => expect(renderer.scene.children[1].children).toBeDefined());
     const axes = renderer.scene.children[1].children;


### PR DESCRIPTION

Closes #220 

# What was the issue
There was a duplicate file name, leading to confusion on what was being used where. 

# What was done and why
Just refactored the name and type inside repo/DataPoint.tsx to RepoDataPoint.tsx. 

# How it was tested
Ran Unit tests, found an error where things were getting tested before render, added a new wait call


