### PR TITLE
#225: DataLayer tests are using the same database concurrently

### DIFF
--- a/my-webxr-app/src/data/DataLayer.tsx
+++ b/my-webxr-app/src/data/DataLayer.tsx
@@ -12,9 +12,9 @@ import { computeCovariancePCA } from '../utils/PcaCovariance';
  * The Data Layer provides a set of methods for working with CSV and PCA data.
  */
 export default class DataLayer implements DataAbstractor {
-  private repository: Repository;
+  protected repository: Repository;
 
-  private isFirstBatch: boolean;
+  protected isFirstBatch: boolean;
 
   /**
    * Create a new Data Layer instance.

--- a/my-webxr-app/tests/data/DataLayer.test.tsx
+++ b/my-webxr-app/tests/data/DataLayer.test.tsx
@@ -1,6 +1,8 @@
 import 'fake-indexeddb/auto';
-import { describe, expect } from 'vitest';
+import { afterEach, describe, expect } from 'vitest';
 import { Matrix } from 'ml-matrix';
+import { v4 as uuidv4 } from 'uuid';
+import Dexie from 'dexie';
 import PrivilegedDataLayer from './PrivilegedDataLayer';
 import DataLayer, { BatchedDataStream } from '../../src/data/DataLayer';
 import Column, {
@@ -175,13 +177,23 @@ describe('Validate calculateColumnsStatistics() operation', () => {
 });
 
 describe('Validate storeCSV() operation', () => {
+  let dbName: string;
   let dataLayer: DataLayer;
   let repository: Repository;
 
   beforeEach(() => {
-    indexedDB.deleteDatabase('Test_DB');
-    repository = new DbRepository('Test_DB');
-    dataLayer = new DataLayer('Test_DB');
+    dbName = `Test_DB${uuidv4()}`;
+    expect(Dexie.exists(dbName)).resolves.toBe(false);
+
+    dataLayer = new PrivilegedDataLayer(dbName);
+    // We can't create a new repository as that would make two connections to the same DB.
+    repository = (dataLayer as PrivilegedDataLayer).getInternalRepository();
+  });
+
+  afterEach(async () => {
+    // Close connection before deleting; this is private, so we need to typecast.
+    (repository as DbRepository).closeConnection();
+    await Dexie.delete(dbName);
   });
 
   test('should store 1 batch correctly', async () => {
@@ -261,6 +273,7 @@ describe('Validate storeCSV() operation', () => {
 });
 
 describe('Validate standardizeQualityColumn() operation', () => {
+  let dbName: string;
   let dataLayer: DataLayer;
   let repository: Repository;
   let testRawColumn: Column<NumericColumn>;
@@ -269,9 +282,18 @@ describe('Validate standardizeQualityColumn() operation', () => {
   let expectStandardizedColumn: Array<number>;
 
   beforeEach(() => {
-    indexedDB.deleteDatabase('Test_DB1');
-    repository = new DbRepository('Test_DB1');
-    dataLayer = new DataLayer('Test_DB1');
+    dbName = `Test_DB${uuidv4()}`;
+    expect(Dexie.exists(dbName)).resolves.toBe(false);
+
+    dataLayer = new PrivilegedDataLayer(dbName);
+    // We can't create a new repository as that would make two connections to the same DB.
+    repository = (dataLayer as PrivilegedDataLayer).getInternalRepository();
+  });
+
+  afterEach(async () => {
+    // Close connection before deleting; this is private, so we need to typecast.
+    (repository as DbRepository).closeConnection();
+    await Dexie.delete(dbName);
   });
 
   test('standardizeColumn - Standardize a numeric column', async () => {
@@ -328,15 +350,25 @@ describe('Validate standardizeQualityColumn() operation', () => {
 });
 
 describe('Validate writeStandardizedData() operation', () => {
+  let dbName: string;
   let dataLayer: DataLayer;
   let repository: Repository;
   let testRawColumn: Column<NumericColumn>;
   let testStatsColumn: Column<StatsColumn>;
 
   beforeEach(() => {
-    indexedDB.deleteDatabase('Test_DB2');
-    repository = new DbRepository('Test_DB2');
-    dataLayer = new DataLayer('Test_DB2');
+    dbName = `Test_DB${uuidv4()}`;
+    expect(Dexie.exists(dbName)).resolves.toBe(false);
+
+    dataLayer = new PrivilegedDataLayer(dbName);
+    // We can't create a new repository as that would make two connections to the same DB.
+    repository = (dataLayer as PrivilegedDataLayer).getInternalRepository();
+  });
+
+  afterEach(async () => {
+    // Close connection before deleting; this is private, so we need to typecast.
+    (repository as DbRepository).closeConnection();
+    await Dexie.delete(dbName);
   });
 
   test('writeStandardizedData - Standardize on quality column and save', async () => {
@@ -390,15 +422,25 @@ describe('Validate writeStandardizedData() operation', () => {
 });
 
 describe('Validate getAvailableFields operation', () => {
+  let dbName: string;
   let dataLayer: DataLayer;
   let repository: Repository;
   let testPCAColumn: Column<NumericColumn>;
   let testStatsColumn: Column<StatsColumn>;
 
   beforeEach(() => {
-    indexedDB.deleteDatabase('Test_DB3');
-    repository = new DbRepository('Test_DB3');
-    dataLayer = new DataLayer('Test_DB3');
+    dbName = `Test_DB${uuidv4()}`;
+    expect(Dexie.exists(dbName)).resolves.toBe(false);
+
+    dataLayer = new PrivilegedDataLayer(dbName);
+    // We can't create a new repository as that would make two connections to the same DB.
+    repository = (dataLayer as PrivilegedDataLayer).getInternalRepository();
+  });
+
+  afterEach(async () => {
+    // Close connection before deleting; this is private, so we need to typecast.
+    (repository as DbRepository).closeConnection();
+    await Dexie.delete(dbName);
   });
 
   test('getAvailableFields - Get column from both tables', async () => {
@@ -446,6 +488,7 @@ describe('Validate getAvailableFields operation', () => {
 });
 
 describe('Validate getColumnsForPca operation', () => {
+  let dbName: string;
   let dataLayer: DataLayer;
   let repository: Repository;
   let column1: Column<NumericColumn>;
@@ -453,9 +496,18 @@ describe('Validate getColumnsForPca operation', () => {
   let columnNames: string[];
 
   beforeEach(() => {
-    indexedDB.deleteDatabase('Test_DB4');
-    repository = new DbRepository('Test_DB4');
-    dataLayer = new DataLayer('Test_DB4');
+    dbName = `Test_DB${uuidv4()}`;
+    expect(Dexie.exists(dbName)).resolves.toBe(false);
+
+    dataLayer = new PrivilegedDataLayer(dbName);
+    // We can't create a new repository as that would make two connections to the same DB.
+    repository = (dataLayer as PrivilegedDataLayer).getInternalRepository();
+  });
+
+  afterEach(async () => {
+    // Close connection before deleting; this is private, so we need to typecast.
+    (repository as DbRepository).closeConnection();
+    await Dexie.delete(dbName);
   });
 
   test('getColumnsForPca - get standardized columns', async () => {
@@ -504,6 +556,7 @@ describe('Validate getColumnsForPca operation', () => {
 });
 
 describe('Validate calculatePCA operation', () => {
+  let dbName: string;
   let dataLayer: DataLayer;
   let repository: Repository;
   let rawCol1: Column<RawColumn>;
@@ -513,9 +566,18 @@ describe('Validate calculatePCA operation', () => {
   let columnNames: string[];
 
   beforeEach(() => {
-    indexedDB.deleteDatabase('Test_DB5');
-    repository = new DbRepository('Test_DB5');
-    dataLayer = new DataLayer('Test_DB5');
+    dbName = `Test_DB${uuidv4()}`;
+    expect(Dexie.exists(dbName)).resolves.toBe(false);
+
+    dataLayer = new PrivilegedDataLayer(dbName);
+    // We can't create a new repository as that would make two connections to the same DB.
+    repository = (dataLayer as PrivilegedDataLayer).getInternalRepository();
+  });
+
+  afterEach(async () => {
+    // Close connection before deleting; this is private, so we need to typecast.
+    (repository as DbRepository).closeConnection();
+    await Dexie.delete(dbName);
   });
 
   test('getColumnsForPca - test against hard values', async () => {
@@ -553,6 +615,7 @@ describe('Validate calculatePCA operation', () => {
 });
 
 describe('Validate storePCA operation', () => {
+  let dbName: string;
   let dataLayer: DataLayer;
   let repository: Repository;
   let rawCol1: Column<RawColumn>;
@@ -563,9 +626,18 @@ describe('Validate storePCA operation', () => {
   let pcaColumnNames: string[];
 
   beforeEach(() => {
-    indexedDB.deleteDatabase('Test_DB6');
-    repository = new DbRepository('Test_DB6');
-    dataLayer = new DataLayer('Test_DB6');
+    dbName = `Test_DB${uuidv4()}`;
+    expect(Dexie.exists(dbName)).resolves.toBe(false);
+
+    dataLayer = new PrivilegedDataLayer(dbName);
+    // We can't create a new repository as that would make two connections to the same DB.
+    repository = (dataLayer as PrivilegedDataLayer).getInternalRepository();
+  });
+
+  afterEach(async () => {
+    // Close connection before deleting; this is private, so we need to typecast.
+    (repository as DbRepository).closeConnection();
+    await Dexie.delete(dbName);
   });
 
   test('getStorePCA - test that PCA get store correctly', async () => {

--- a/my-webxr-app/tests/data/DataLayer.test.tsx
+++ b/my-webxr-app/tests/data/DataLayer.test.tsx
@@ -1,4 +1,3 @@
-import 'fake-indexeddb/auto';
 import { afterEach, describe, expect } from 'vitest';
 import { Matrix } from 'ml-matrix';
 import { v4 as uuidv4 } from 'uuid';

--- a/my-webxr-app/tests/data/PrivilegedDataLayer.tsx
+++ b/my-webxr-app/tests/data/PrivilegedDataLayer.tsx
@@ -8,6 +8,10 @@ import Column, { NumericColumn } from '../../src/repository/Column';
  * DataLayer that could not be tested otherwise.
  */
 export default class PrivilegedDataLayer extends DataLayer {
+  public getInternalRepository() {
+    return this.repository;
+  }
+
   public static override transposeData(batchItems: BatchedDataStream) {
     return super.transposeData(batchItems);
   }

--- a/my-webxr-app/vitest.setup.ts
+++ b/my-webxr-app/vitest.setup.ts
@@ -1,3 +1,4 @@
 import 'vitest-canvas-mock';
+import 'fake-indexeddb/auto'
 
 global.IS_REACT_ACT_ENVIRONMENT = true;


### PR DESCRIPTION
Closes #225.

# What was the issue
Some of the DataLayer tests were creating both a DataLayer and Repository to conduct testing a database. However, the DataLayer has its own internal Repository, and both of these Repositories were trying to access the database at the same time.

# What was done and why
Spent *way too long* diagnosing the problem and created a method to expose the internal DataLayer Repository instance through the PrivilegedDataLayer for testing. Also setup each test to receive its own database to work in (no more sharing).

# How it was tested
Fixed those tests that weren't correct, and now all tests pass.