### PR TITLE
237 assert is not a function bug

### DIFF
--- a/my-webxr-app/src/App.tsx
+++ b/my-webxr-app/src/App.tsx
@@ -4,6 +4,7 @@ import { Controllers, VRButton, XR } from '@react-three/xr';
 import { openDB } from 'idb';
 import { Provider } from '@rollbar/react';
 import { useEffect } from 'react';
+import * as assert from 'assert';
 import {
   createGraphingDataPoints,
 } from './components/CreateGraphingDataPoints';
@@ -16,6 +17,8 @@ import './styles.css';
 import TestingOptions from './smoketest/TestingOptions';
 import DataPoint from './repository/DataPoint';
 import { rollbarConfig } from './utils/LoggingUtils';
+
+assert.strictEqual(1, 1);
 
 // minNum and maxNum will be from the csv file, just hardcoded for now
 const minNum: number = -10;

--- a/my-webxr-app/src/App.tsx
+++ b/my-webxr-app/src/App.tsx
@@ -4,7 +4,6 @@ import { Controllers, VRButton, XR } from '@react-three/xr';
 import { openDB } from 'idb';
 import { Provider } from '@rollbar/react';
 import { useEffect } from 'react';
-import * as assert from 'assert';
 import {
   createGraphingDataPoints,
 } from './components/CreateGraphingDataPoints';
@@ -17,8 +16,6 @@ import './styles.css';
 import TestingOptions from './smoketest/TestingOptions';
 import DataPoint from './repository/DataPoint';
 import { rollbarConfig } from './utils/LoggingUtils';
-
-assert.strictEqual(1, 1);
 
 // minNum and maxNum will be from the csv file, just hardcoded for now
 const minNum: number = -10;

--- a/my-webxr-app/vite.config.ts
+++ b/my-webxr-app/vite.config.ts
@@ -6,7 +6,20 @@ import { nodePolyfills } from 'vite-plugin-node-polyfills';
 // https://vitejs.dev/config/
 // https://vitest.dev/config/
 export default defineConfig({
-  plugins: [react(), nodePolyfills()],
+  plugins: [react(),
+    // Since browsers do not support Node's Core Modules,
+    // packages that use them must be polyfilled to function in browser environments.
+    nodePolyfills()],
+  resolve: {
+    // 'assert' and 'node:assert' points to the same module
+    // However, the nodePolyfills plugin only polyfill the module entry point "node:assert"
+    // https://www.npmjs.com/package/vite-plugin-node-polyfills
+    // thus, we have to alias the assert module to node:assert
+    // to ensure that we can use the assert whether we import it as 'assert' or 'node:assert'
+    alias: {
+      assert: "node:assert",
+    },
+  },
   test: {
     globals: true,
     environment: "jsdom",


### PR DESCRIPTION
Closes #237

# What was the issue
We're having error "assert is not a function" again

# What was done and why
<img width="886" alt="image" src="https://github.com/UniversityOfSaskatchewanCMPT371/term-project-2024-team-2/assets/66387098/8a228809-fb61-45cf-8b38-fca6b3116ad6">
I considered switching all "assert" import statements to import "node:assert" instead, but then I decided to resolve "assert" to "node:assert" instead. This decision was driven by WebStorm's automatic dependency-import feature, which consistently imports "assert" for some unknown reason. To prevent confusion among developers when using this feature, I chose to treat "assert" and "node:assert" as equivalent.

# How it was tested
- add an assertion in App to check if the assertion function is poly-filled in.

For anyone interested in testing this pull request, you can refer to my second commit within this PR where I added an assertion in the App to do testing.
