### PR TITLE
#241: Fix Staging Deployment

### DIFF
--- a/.github/workflows/deployment_prod.yml
+++ b/.github/workflows/deployment_prod.yml
@@ -14,9 +14,7 @@ defaults:
 jobs:
   build_test_deploy_review:
     name: Build - Test - Deploy Preview
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/deployment_dev.yml
+    uses: ./.github/workflows/deployment_dev.yml
 
   build_and_deploy_to_production:
     name: Deploy to Production

--- a/.github/workflows/deployment_staging.yml
+++ b/.github/workflows/deployment_staging.yml
@@ -14,9 +14,7 @@ defaults:
 jobs:
   build_test_deploy_review:
     name: Build - Test - Deploy Preview
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/deployment_dev.yml
+    uses: ./.github/workflows/deployment_dev.yml
 
   build_and_deploy_to_staging:
     name: Staging


### PR DESCRIPTION
Closes #241 

# What was the issue
Our workflow to deploy the staging/production build to Firebase had a small syntax issue. We called our reusable workflow as a step, but it must be a distinct job: https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow

# What was done and why
Corrected the syntax to call our reusable workflow as a distinct job.

# How it was tested
We will find out when this PR is merged 👀