### PR TITLE
#241: Fix Staging Deployment (Attempt 2)

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           fail-on-severity: moderate
           comment-summary-in-pr: on-failure
+        if: github.event_name == 'pull_request'
 
       - name: Build Application
         run: npm run build


### PR DESCRIPTION
Closes #241 

# What was the issue
Our build step includes an action to scan dependencies and the changes that occur between PRs. This action requires a PR base and head commit reference to compare dependencies between. These PR variables are not present in `commit` events.

# What was done and why
Since the dependency review action requires base/head commit references, only run the action on PR events when those references exist. The action doesn't need to run when we're going to deploy. Added a conditional to run the dependency review action ONLY on PR events.

# How it was tested
We'll find out when this is merged 👀👀