### PR TITLE
252 bug assert is used without being imported and csvurlreader doesnt calculate stats and pca upon loading file

### DIFF
--- a/my-webxr-app/src/utils/CsvUtils.tsx
+++ b/my-webxr-app/src/utils/CsvUtils.tsx
@@ -1,5 +1,6 @@
 import Papa from 'papaparse';
 import React from 'react';
+import * as assert from 'assert';
 import DataAbstractor from '../data/DataAbstractor';
 
 /**
@@ -23,9 +24,9 @@ async function parseAndHandleUrlCsv(
   setMessage: React.Dispatch<React.SetStateAction<string | null>>,
 ) {
   const completeData = Array<Array<string | number>>();
-  assert(url !== null || url !== undefined, 'No URL provided');
-  assert(DAL !== null || DAL !== undefined, 'No Data Abstractor provided');
-  assert(setMessage !== null || setMessage !== undefined, 'No setMessage function provided');
+  assert.ok(url !== null || url !== undefined, 'No URL provided');
+  assert.ok(DAL !== null || DAL !== undefined, 'No Data Abstractor provided');
+  assert.ok(setMessage !== null || setMessage !== undefined, 'No setMessage function provided');
   // Normalize headers by appending a number to duplicate headers, takes in an array of string
   // headers
   await DAL.resetFlag();

--- a/my-webxr-app/src/utils/CsvUtils.tsx
+++ b/my-webxr-app/src/utils/CsvUtils.tsx
@@ -78,6 +78,9 @@ async function parseAndHandleUrlCsv(
         await DAL.storeCSV(sanitizedBatch);
       }
       setMessage('Url CSV loaded successfully');
+      await DAL.calculateStatistics();
+      await DAL.storeStandardizedData();
+      await DAL.storePCA(await DAL.getAvailableFields());
     },
   });
 }


### PR DESCRIPTION
Closes #252 

# What was the issue
- assert is used without being imported in
- CsvUrlReader doesn't calculate stats and pca upon loading CSV file

# What was done and why
- import assert module
- calculate stats and pca upon loading CSV file

# How it was tested
<img width="1363" alt="image" src="https://github.com/UniversityOfSaskatchewanCMPT371/term-project-2024-team-2/assets/66387098/cae681b1-21bd-4514-b2ec-0df7a0417abe">
the stats and pca tables are populated after raw csv data is stored


