### PR TITLE
#246 Optimization: Convert DataPoints from spheres to tetrahedrons

### DIFF
--- a/my-webxr-app/src/components/CreateGraphingDataPoints.tsx
+++ b/my-webxr-app/src/components/CreateGraphingDataPoints.tsx
@@ -91,7 +91,7 @@ export default function CreateGraphingDataPoints({
             columnY={selectedYAxis as string}
             columnZ={selectedZAxis as string}
             actualData={[dataPoint.xValue, dataPoint.yValue, dataPoint.zValue]}
-            size={[0.02, 32, 32]}
+            size={[0.02, 0]}
             meshProps={{ position }}
           />
         );

--- a/my-webxr-app/src/components/GraphingDataPoint.tsx
+++ b/my-webxr-app/src/components/GraphingDataPoint.tsx
@@ -76,24 +76,25 @@ export default function GraphingDataPoint({
       >
         {/* Low numbers to try to minimize the number of faces we need to render */}
         {/* There will be a LOT of these present in the simulation */}
-        <sphereGeometry args={size} />
+        <octahedronGeometry args={size} />
         <meshStandardMaterial color="yellow" />
       </mesh>
 
       {/* This second mesh is the outline which works by rendering */}
       {/* only the BackSide of the mesh material */}
+      {(hoverCount !== 0 || selectedDataPoint?.id === id) && (
       <mesh
         name="point sphere"
         {...meshProps}
         scale={outlineScale}
-        visible={hoverCount !== 0 || selectedDataPoint?.id === id}
       >
-        <sphereGeometry args={size} />
+        <octahedronGeometry args={size} />
         <meshStandardMaterial
           color={selectedDataPoint?.id === id ? 'darkorange' : 'purple'}
           side={BackSide}
         />
       </mesh>
+      )}
     </Interactive>
   );
 }

--- a/my-webxr-app/src/types/DataPointTypes.tsx
+++ b/my-webxr-app/src/types/DataPointTypes.tsx
@@ -1,4 +1,4 @@
-import { SphereGeometryProps } from '@react-three/fiber';
+import { OctahedronGeometryProps } from '@react-three/fiber';
 
 /**
  * Define an interface to require an ID number to differentiate each GraphingDataPoint
@@ -13,6 +13,6 @@ export interface DataPointProps {
   marker: string
   actualData?: number[];
   outlineScale?: number;
-  size?: SphereGeometryProps['args'];
+  size?: OctahedronGeometryProps['args'];
   meshProps?: JSX.IntrinsicElements['mesh'];
 }

--- a/my-webxr-app/tests/components/CreateGraphingDataPoints.test.tsx
+++ b/my-webxr-app/tests/components/CreateGraphingDataPoints.test.tsx
@@ -9,7 +9,7 @@ import CreateGraphingDataPoints from '../../src/components/CreateGraphingDataPoi
 import { rollbarConfig } from '../../src/utils/LoggingUtils';
 import DataAbstractor, { getDatabase } from '../../src/data/DataAbstractor';
 import { useAxesSelectionContext } from '../../src/contexts/AxesSelectionContext';
-import { usePointSelectionContext } from '../../src/contexts/PointSelectionContext.tsx';
+import { usePointSelectionContext } from '../../src/contexts/PointSelectionContext';
 
 // TODO: These values are based on the hard-coded values in CreateGraphingDataPoints and will
 //  have to be updated when the hardcoded values are removed.

--- a/my-webxr-app/tests/components/CreateGraphingDataPoints.test.tsx
+++ b/my-webxr-app/tests/components/CreateGraphingDataPoints.test.tsx
@@ -4,12 +4,12 @@ import { Vector3 } from 'three';
 import { expect } from 'vitest';
 import { Provider } from '@rollbar/react';
 import Dexie from 'dexie';
-import { PointSelectionProvider } from '../../src/contexts/PointSelectionContext';
 import MockServer from '../MockServer';
 import CreateGraphingDataPoints from '../../src/components/CreateGraphingDataPoints';
 import { rollbarConfig } from '../../src/utils/LoggingUtils';
 import DataAbstractor, { getDatabase } from '../../src/data/DataAbstractor';
 import { useAxesSelectionContext } from '../../src/contexts/AxesSelectionContext';
+import { usePointSelectionContext } from '../../src/contexts/PointSelectionContext.tsx';
 
 // TODO: These values are based on the hard-coded values in CreateGraphingDataPoints and will
 //  have to be updated when the hardcoded values are removed.
@@ -21,6 +21,7 @@ const positions = [
   new Vector3(-0.1, 1.4, -1.6),
 ];
 
+vi.mock('../../src/contexts/PointSelectionContext');
 vi.mock('../../src/contexts/AxesSelectionContext');
 
 describe('createGraphingDataPoints', () => {
@@ -48,6 +49,18 @@ describe('createGraphingDataPoints', () => {
     ];
     await database.storeCSV(batchItems);
 
+    vi.mocked(usePointSelectionContext).mockReturnValue({
+      selectedDataPoint: {
+        id: -1,
+        columnX: '',
+        columnY: '',
+        columnZ: '',
+        marker: '',
+        color: '',
+      },
+      setSelectedDataPoint: vi.fn(),
+    });
+
     vi.mocked(useAxesSelectionContext).mockReturnValue({
       selectedXAxis: 'colX',
       setSelectedXAxis: vi.fn(),
@@ -59,17 +72,15 @@ describe('createGraphingDataPoints', () => {
 
     const render = await ReactThreeTestRenderer.create(
       <Provider config={rollbarConfig}>
-        <PointSelectionProvider>
-          <XR>
-            <CreateGraphingDataPoints
-              scaleFactor={2}
-              startX={0}
-              startY={1.5}
-              startZ={-1.5}
-              database={database}
-            />
-          </XR>
-        </PointSelectionProvider>
+        <XR>
+          <CreateGraphingDataPoints
+            scaleFactor={2}
+            startX={0}
+            startY={1.5}
+            startZ={-1.5}
+            database={database}
+          />
+        </XR>
       </Provider>,
     );
 
@@ -80,19 +91,19 @@ describe('createGraphingDataPoints', () => {
 
     // Children 0 is the camera
     // Children 1-5 are the points, check position and name
-    expect(render.scene.children[1].children[1].instance.position.equals(positions[0])).toBe(true);
-    expect(render.scene.children[1].children[1].instance.name).toEqual('point sphere');
+    expect(render.scene.children[1].children[0].instance.position.equals(positions[0])).toBe(true);
+    expect(render.scene.children[1].children[0].instance.type).toEqual('Mesh');
 
-    expect(render.scene.children[2].children[1].instance.position.equals(positions[1])).toBe(true);
-    expect(render.scene.children[2].children[1].instance.name).toEqual('point sphere');
+    expect(render.scene.children[2].children[0].instance.position.equals(positions[1])).toBe(true);
+    expect(render.scene.children[2].children[0].instance.type).toEqual('Mesh');
 
-    expect(render.scene.children[3].children[1].instance.position.equals(positions[2])).toBe(true);
-    expect(render.scene.children[3].children[1].instance.name).toEqual('point sphere');
+    expect(render.scene.children[3].children[0].instance.position.equals(positions[2])).toBe(true);
+    expect(render.scene.children[3].children[0].instance.type).toEqual('Mesh');
 
-    expect(render.scene.children[4].children[1].instance.position.equals(positions[3])).toBe(true);
-    expect(render.scene.children[4].children[1].instance.name).toEqual('point sphere');
+    expect(render.scene.children[4].children[0].instance.position.equals(positions[3])).toBe(true);
+    expect(render.scene.children[4].children[0].instance.type).toEqual('Mesh');
 
-    expect(render.scene.children[5].children[1].instance.position.equals(positions[4])).toBe(true);
-    expect(render.scene.children[5].children[1].instance.name).toEqual('point sphere');
+    expect(render.scene.children[5].children[0].instance.position.equals(positions[4])).toBe(true);
+    expect(render.scene.children[5].children[0].instance.type).toEqual('Mesh');
   });
 });

--- a/my-webxr-app/tests/components/GraphingDataPoint.test.tsx
+++ b/my-webxr-app/tests/components/GraphingDataPoint.test.tsx
@@ -2,36 +2,51 @@ import ReactThreeTestRenderer from '@react-three/test-renderer';
 import { XR } from '@react-three/xr';
 import { Vector3 } from 'three';
 import { Provider } from '@rollbar/react';
-import { PointSelectionProvider } from '../../src/contexts/PointSelectionContext';
+import {
+  usePointSelectionContext,
+} from '../../src/contexts/PointSelectionContext';
 import GraphingDataPoint from '../../src/components/GraphingDataPoint';
 import { rollbarConfig } from '../../src/utils/LoggingUtils';
+
+vi.mock('../../src/contexts/PointSelectionContext');
 
 describe('GraphingDataPoint Creation and Interaction', () => {
   test('creating a basic GraphingDataPoint with defaults', async () => {
     const renderer = await ReactThreeTestRenderer.create(
       <Provider config={rollbarConfig}>
-        <PointSelectionProvider>
-          <XR>
-            <GraphingDataPoint id={0} marker="circle" color="gray" columnX="John Doe" columnY="cmpt 145" columnZ="97" />
-          </XR>
-        </PointSelectionProvider>
+        <XR>
+          <GraphingDataPoint
+            id={0}
+            marker="circle"
+            color="gray"
+            columnX="John Doe"
+            columnY="cmpt 145"
+            columnZ="97"
+          />
+        </XR>
       </Provider>,
     );
 
     // Expect the GraphingDataPoint component to be created, along with its two meshes with
     // default values.
     expect(renderer.scene.children.length).toEqual(2); // + native camera component = 2
-    expect(renderer.scene.children[1].children.length).toEqual(2);
+    expect(renderer.scene.children[1].children.length).toEqual(1);
   });
 
   test('creating a basic GraphingDataPoint and assign position', async () => {
     const renderer = await ReactThreeTestRenderer.create(
       <Provider config={rollbarConfig}>
-        <PointSelectionProvider>
-          <XR>
-            <GraphingDataPoint id={0} marker="circle" color="gray" columnX="John Doe" columnY="cmpt 145" columnZ="97" meshProps={{ position: [1, 2, 3] }} />
-          </XR>
-        </PointSelectionProvider>
+        <XR>
+          <GraphingDataPoint
+            id={0}
+            marker="circle"
+            color="gray"
+            columnX="John Doe"
+            columnY="cmpt 145"
+            columnZ="97"
+            meshProps={{ position: [1, 2, 3] }}
+          />
+        </XR>
       </Provider>,
     );
 
@@ -41,14 +56,66 @@ describe('GraphingDataPoint Creation and Interaction', () => {
     )).toBe(true);
   });
 
-  test('creating a basic GraphingDataPoint and assign outline scale', async () => {
+  test('creating a basic GraphingDataPoint and fake selection', async () => {
+    // Pretend this point has been selected, so the outline mesh exists.
+    vi.mocked(usePointSelectionContext).mockReturnValue({
+      selectedDataPoint: {
+        id: 0,
+        columnX: 'John Doe',
+        columnY: 'cmpt 145',
+        columnZ: '97',
+        marker: 'circle',
+        color: 'gray',
+      },
+      setSelectedDataPoint: vi.fn(),
+    });
+
     const renderer = await ReactThreeTestRenderer.create(
       <Provider config={rollbarConfig}>
-        <PointSelectionProvider>
-          <XR>
-            <GraphingDataPoint id={0} marker="circle" color="gray" columnX="John Doe" columnY="cmpt 145" columnZ="97" outlineScale={2} />
-          </XR>
-        </PointSelectionProvider>
+        <XR>
+          <GraphingDataPoint
+            id={0}
+            marker="circle"
+            color="gray"
+            columnX="John Doe"
+            columnY="cmpt 145"
+            columnZ="97"
+          />
+        </XR>
+      </Provider>,
+    );
+
+    // Check if the outline mesh exists.
+    expect(renderer.scene.children[1].children.length).equals(2);
+  });
+
+  test('creating a basic GraphingDataPoint and assign outline scale', async () => {
+    // Pretend this point has been selected, so the outline mesh exists.
+    vi.mocked(usePointSelectionContext).mockReturnValue({
+      selectedDataPoint: {
+        id: 0,
+        columnX: 'John Doe',
+        columnY: 'cmpt 145',
+        columnZ: '97',
+        marker: 'circle',
+        color: 'gray',
+      },
+      setSelectedDataPoint: vi.fn(),
+    });
+
+    const renderer = await ReactThreeTestRenderer.create(
+      <Provider config={rollbarConfig}>
+        <XR>
+          <GraphingDataPoint
+            id={0}
+            marker="circle"
+            color="gray"
+            columnX="John Doe"
+            columnY="cmpt 145"
+            columnZ="97"
+            outlineScale={2}
+          />
+        </XR>
       </Provider>,
     );
 
@@ -60,14 +127,32 @@ describe('GraphingDataPoint Creation and Interaction', () => {
 });
 
 describe('GraphingDataPoint UI Interaction', () => {
+  // This point is not selected
+  vi.mocked(usePointSelectionContext).mockReturnValue({
+    selectedDataPoint: {
+      id: -1,
+      columnX: '',
+      columnY: '',
+      columnZ: '',
+      marker: '',
+      color: '',
+    },
+    setSelectedDataPoint: vi.fn(),
+  });
+
   test('create a basic GraphingDataPoint and check all its fields', async () => {
     const renderer = await ReactThreeTestRenderer.create(
       <Provider config={rollbarConfig}>
-        <PointSelectionProvider>
-          <XR>
-            <GraphingDataPoint id={0} marker="circle" color="gray" columnX="John Doe" columnY="cmpt 145" columnZ="97" />
-          </XR>
-        </PointSelectionProvider>
+        <XR>
+          <GraphingDataPoint
+            id={0}
+            marker="circle"
+            color="gray"
+            columnX="John Doe"
+            columnY="cmpt 145"
+            columnZ="97"
+          />
+        </XR>
       </Provider>,
     );
 


### PR DESCRIPTION
Closes #246

# What was the issue
Each DataPoint rendered as a sphere which led to poor performance on the Quest. Dr. Osgood recommended reducing the face count at the stakeholder meeting (to my knowledge since I wasn't there).

# What was done and why
Reduced the number of faces per DataPoint by an order of magnitude by switching from a SphereGeometry to OctahedronGeometry (8 faces). Also tested with TetrahedronGeometry (4 faces), but the non-symmetrical shape was disconcerting in VR.

Also introduced an optimization to the selection outline mesh: prior, its visibility was just toggled (it always existed), but now it does not get created unless the DataPoint is selected. This should help as each DataPoint won't have an extra mesh object to store; it only gets created/removed on selection/deselection.

# How it was tested
Inspected in VR. Fixed some of the tests that broke from the removed selection mesh (while not selected) by mocking the PointSelectionContext to make the DataPoint think it was selected. This also allowed creation of a test to check whether the selection mesh appeared when selected.
![Screenshot 2024-04-01 at 18 52 17](https://github.com/UniversityOfSaskatchewanCMPT371/term-project-2024-team-2/assets/76539691/c801f1f3-7dc3-4c2e-850a-1f0110a2e503)