### PR TITLE
#203: Add testing utils to display loaded data

### DIFF
--- a/my-webxr-app/src/smoketest/TestingOptions.tsx
+++ b/my-webxr-app/src/smoketest/TestingOptions.tsx
@@ -30,10 +30,9 @@ export default function TestingOptions() {
 
   const viewDatabase = async () => {
     const db = await openDB('CsvDataBase');
-    // eslint-disable-next-line no-alert
-    // alert(JSON.stringify(await db.getAll('rawColumns'), null, 2));
-    // console.log(JSON.stringify(await db.getAll('rawColumns'), null, 2));
-    // Hacky "alert" to show everything in the Database
+
+    // Hacky "alert/modal" to show everything in the Database. It has to be created this way in
+    // order to appear in front of everything (we can't just put it in the React component).
     const popup = document.getElementById('root')?.appendChild(document.createElement('div'));
     if (typeof popup === 'undefined') {
       db.close();

--- a/my-webxr-app/src/smoketest/TestingOptions.tsx
+++ b/my-webxr-app/src/smoketest/TestingOptions.tsx
@@ -1,3 +1,7 @@
+/* eslint-disable no-console, func-names */
+
+import { openDB } from 'idb';
+
 /**
  * Creates a DOM element to access smoke testing functionalities
  * @pre-condition None
@@ -24,10 +28,59 @@ export default function TestingOptions() {
     URL.revokeObjectURL(url);
   };
 
+  const viewDatabase = async () => {
+    const db = await openDB('CsvDataBase');
+    // eslint-disable-next-line no-alert
+    // alert(JSON.stringify(await db.getAll('rawColumns'), null, 2));
+    // console.log(JSON.stringify(await db.getAll('rawColumns'), null, 2));
+    // Hacky "alert" to show everything in the Database
+    const popup = document.getElementById('root')?.appendChild(document.createElement('div'));
+    if (typeof popup === 'undefined') {
+      db.close();
+      return Promise.reject(new Error('Failed to show DB popup'));
+    }
+    popup.id = 'db_popup';
+    popup.style.position = 'absolute';
+    popup.style.top = '0px';
+    popup.style.width = '100%';
+    popup.style.height = '100%';
+    popup.style.backgroundColor = '#202020';
+
+    const close = popup.appendChild(document.createElement('button'));
+    close.id = 'db_popup_close';
+    close.style.position = 'absolute';
+    close.style.top = '0px';
+    close.style.right = '0px';
+    close.style.width = '5vw';
+    close.style.height = '5vw';
+    close.style.fontWeight = '800';
+    close.style.fontSize = 'x-large';
+    close.innerText = 'X';
+    close.onclick = function () {
+      document.getElementById('db_popup')?.remove();
+    };
+
+    const content = popup.appendChild(document.createElement('pre'));
+    content.id = 'db_popup_text';
+    content.style.padding = '1vw';
+    content.innerText = '### RAW DATA (rawColumns) ###\n';
+    content.innerText += JSON.stringify(await db.getAll('rawColumns'), null, 4);
+    content.innerText += '\n\n### STATS DATA (statsColumns) ###\n';
+    content.innerText += JSON.stringify(await db.getAll('statsColumns'), null, 4);
+    content.innerText += '\n\n### STANDARDIZED DATA (standardizedColumns) ###\n';
+    content.innerText += JSON.stringify(await db.getAll('standardizedColumns'), null, 4);
+    content.innerText += '\n\n### PCA DATA (pcaColumns) ###\n';
+    content.innerText += JSON.stringify(await db.getAll('pcaColumns'), null, 4);
+    content.innerText += '\n';
+
+    return Promise.resolve('DB popup created');
+  };
+
   return (
     <div>
       <button type="button" onClick={handleButtonClick}>Begin Test</button>
       <button type="button" onClick={downloadText}>Download</button>
+      <button type="button" onClick={viewDatabase}>View Database</button>
     </div>
   );
 }

--- a/my-webxr-app/src/smoketest/TestingOptions.tsx
+++ b/my-webxr-app/src/smoketest/TestingOptions.tsx
@@ -72,6 +72,7 @@ export default function TestingOptions() {
     content.innerText += JSON.stringify(await db.getAll('pcaColumns'), null, 4);
     content.innerText += '\n';
 
+    db.close();
     return Promise.resolve('DB popup created');
   };
 


### PR DESCRIPTION
Closes #203 

# What was the issue
We did not have a way to view what data is loaded while on the Quest, since it cannot open the browser console.

# What was done and why
Added a button to the testing menu that opens a new modal to view everything in the DAL.

# How it was tested
⬇️⬇️⬇️

https://github.com/UniversityOfSaskatchewanCMPT371/term-project-2024-team-2/assets/76539691/504a8ff6-c469-4f84-adbf-a5bffee93769

That yellow bar appears to be part of the Three canvas and I couldn't get in front of it, so I guess we have to tolerate it.