### PR TITLE
#275 - refactor menu datapoint to display additonal column values

### DIFF
--- a/my-webxr-app/src/components/CreateGraphingDataPoints.tsx
+++ b/my-webxr-app/src/components/CreateGraphingDataPoints.tsx
@@ -49,7 +49,18 @@ export default function CreateGraphingDataPoints({
   database,
 }: CreateGraphingDataPointsProps): JSX.Element {
   const rollbar = useRollbar();
-  const { selectedXAxis, selectedYAxis, selectedZAxis } = useAxesSelectionContext();
+  const {
+    selectedXAxis,
+    selectedYAxis,
+    selectedZAxis,
+    selectedOptionalColumn1,
+    selectedOptionalColumn2,
+    selectedOptionalColumn3,
+    selectedOptionalColumn4,
+    selectedOptionalColumn5,
+    selectedOptionalColumn6,
+    selectedOptionalColumn7,
+  } = useAxesSelectionContext();
   const [dataPoints, setDataPoints] = useState([]);
   const [maxValues, setMaxValues] = useState([]);
   useEffect(() => {
@@ -58,6 +69,13 @@ export default function CreateGraphingDataPoints({
         selectedXAxis as string,
         selectedYAxis as string,
         selectedZAxis as string,
+        selectedOptionalColumn1 as string,
+        selectedOptionalColumn2 as string,
+        selectedOptionalColumn3 as string,
+        selectedOptionalColumn4 as string,
+        selectedOptionalColumn5 as string,
+        selectedOptionalColumn6 as string,
+        selectedOptionalColumn7 as string,
       ).then((result) => {
         const [dataPointsArray, maxValuesArray] = result;
         setDataPoints(dataPointsArray as never);
@@ -68,7 +86,18 @@ export default function CreateGraphingDataPoints({
       });
     };
     fetchData();
-  }, [selectedXAxis, selectedYAxis, selectedZAxis]);
+  }, [
+    selectedXAxis,
+    selectedYAxis,
+    selectedZAxis,
+    selectedOptionalColumn1,
+    selectedOptionalColumn2,
+    selectedOptionalColumn3,
+    selectedOptionalColumn4,
+    selectedOptionalColumn5,
+    selectedOptionalColumn6,
+    selectedOptionalColumn7,
+  ]);
   return (
     <>
       { (dataPoints as DataPoint[]).map((dataPoint, index) => {
@@ -90,7 +119,25 @@ export default function CreateGraphingDataPoints({
             columnX={selectedXAxis as string}
             columnY={selectedYAxis as string}
             columnZ={selectedZAxis as string}
+            optionalColumns={[
+              selectedOptionalColumn1 ?? '',
+              selectedOptionalColumn2 ?? '',
+              selectedOptionalColumn3 ?? '',
+              selectedOptionalColumn4 ?? '',
+              selectedOptionalColumn5 ?? '',
+              selectedOptionalColumn6 ?? '',
+              selectedOptionalColumn7 ?? '',
+            ]}
             actualXYZData={[dataPoint.xValue, dataPoint.yValue, dataPoint.zValue]}
+            optionalColumnData={[
+              dataPoint.optionalCol1Value as unknown as string ?? '',
+              dataPoint.optionalCol2Value as unknown as string ?? '',
+              dataPoint.optionalCol3Value as unknown as string ?? '',
+              dataPoint.optionalCol4Value as unknown as string ?? '',
+              dataPoint.optionalCol5Value as unknown as string ?? '',
+              dataPoint.optionalCol6Value as unknown as string ?? '',
+              dataPoint.optionalCol7Value as unknown as string ?? '',
+            ]}
             size={[0.02, 0]}
             meshProps={{ position }}
           />

--- a/my-webxr-app/src/components/CreateGraphingDataPoints.tsx
+++ b/my-webxr-app/src/components/CreateGraphingDataPoints.tsx
@@ -90,7 +90,7 @@ export default function CreateGraphingDataPoints({
             columnX={selectedXAxis as string}
             columnY={selectedYAxis as string}
             columnZ={selectedZAxis as string}
-            actualData={[dataPoint.xValue, dataPoint.yValue, dataPoint.zValue]}
+            actualXYZData={[dataPoint.xValue, dataPoint.yValue, dataPoint.zValue]}
             size={[0.02, 0]}
             meshProps={{ position }}
           />

--- a/my-webxr-app/src/components/CsvReader.tsx
+++ b/my-webxr-app/src/components/CsvReader.tsx
@@ -98,7 +98,7 @@ export default function LocalCsvReader({
           }
           await DAL.calculateStatistics();
           await DAL.storeStandardizedData();
-          await DAL.storePCA(await DAL.getAvailableFields());
+          // await DAL.storePCA(await DAL.getAvailableFields());
           resolve('success');
         },
         error: (error) => {

--- a/my-webxr-app/src/components/GraphingDataPoint.tsx
+++ b/my-webxr-app/src/components/GraphingDataPoint.tsx
@@ -17,9 +17,10 @@ import WriteHook from '../../smoketests/TestHookWrite';
  * @param {string} columnY the name of the y-axis data column
  * @param {string} columnZ the name of the z-axis data column
  * @param {string[]} optionalColumns the names of the optional data columns
- * @param {number[] | undefined} actualXYZData the data to assign to the datapoint
+ * @param {number[] | undefined} actualXYZData the x, y ,z data to assign to the datapoint
  * @param {number | undefined} outlineScale the amount of outline to put around a hovered
  *    data element
+ * @param optionalColumnData the optional data to assign to the datapoint
  * @param {[radius: number | undefined, widthSegments: number | undefined,
  *    heightSegments: number | undefined, phiStart: number | undefined,
  *    phiLength: number | undefined, thetaStart: number | undefined,
@@ -82,6 +83,7 @@ export default function GraphingDataPoint({
             columnX,
             columnY,
             columnZ,
+            optionalColumns,
             actualXYZData,
             optionalColumnData,
             meshProps,

--- a/my-webxr-app/src/components/GraphingDataPoint.tsx
+++ b/my-webxr-app/src/components/GraphingDataPoint.tsx
@@ -16,9 +16,10 @@ import WriteHook from '../../smoketests/TestHookWrite';
  * @param {string} columnX the name of the x-axis data column
  * @param {string} columnY the name of the y-axis data column
  * @param {string} columnZ the name of the z-axis data column
+ * @param {string[]} optionalColumns the names of the optional data columns
+ * @param {number[] | undefined} actualXYZData the data to assign to the datapoint
  * @param {number | undefined} outlineScale the amount of outline to put around a hovered
  *    data element
- * @param {number[] | undefined} actualData the data to assign to the datapoint
  * @param {[radius: number | undefined, widthSegments: number | undefined,
  *    heightSegments: number | undefined, phiStart: number | undefined,
  *    phiLength: number | undefined, thetaStart: number | undefined,
@@ -32,7 +33,18 @@ import WriteHook from '../../smoketests/TestHookWrite';
  * @constructor
  */
 export default function GraphingDataPoint({
-  id, marker, color, columnX, columnY, columnZ, outlineScale, actualData, size, meshProps,
+  id,
+  marker,
+  color,
+  columnX,
+  columnY,
+  columnZ,
+  optionalColumns,
+  outlineScale,
+  actualXYZData,
+  optionalColumnData,
+  size,
+  meshProps,
 }: DataPointProps): JSX.Element {
   /* State for the count of controllers hovering over the GraphingDataPoint */
   const [hoverCount, setHoverCount] = useState(0);
@@ -64,16 +76,32 @@ export default function GraphingDataPoint({
         // Update point to be selected and set its fields
         } else {
           setSelectedDataPoint({
-            id, marker, color, columnX, columnY, columnZ, actualData, meshProps,
+            id,
+            marker,
+            color,
+            columnX,
+            columnY,
+            columnZ,
+            actualXYZData,
+            optionalColumnData,
+            meshProps,
           });
-          WriteHook(`${String(actualData)} : `);
+          WriteHook(`${String(actualXYZData)} : `);
         }
       }}
     >
       {/* This first mesh stores custom data about the GraphingDataPoint */}
       <mesh
         userData={{
-          id, columnX, columnY, columnZ, marker, actualData, color,
+          id,
+          columnX,
+          columnY,
+          columnZ,
+          optionalColumns,
+          marker,
+          actualXYZData,
+          optionalColumnData,
+          color,
         }}
         {...meshProps}
       >

--- a/my-webxr-app/src/components/GraphingDataPointMenu.tsx
+++ b/my-webxr-app/src/components/GraphingDataPointMenu.tsx
@@ -58,16 +58,16 @@ export default function GraphingDataPointMenu(
           {WriteHook(`${String(selectedDataPoint?.color)} : `)}
 
           {`(x-axis) ${selectedDataPoint?.columnX ?? '-'}: ${
-            selectedDataPoint?.actualData
-              ? `${selectedDataPoint.actualData[0]}` : '_'}\n`}
+            selectedDataPoint?.actualXYZData
+              ? `${selectedDataPoint.actualXYZData[0]}` : '_'}\n`}
 
           {`(y-axis) ${selectedDataPoint?.columnY ?? '-'}: ${
-            selectedDataPoint?.actualData
-              ? `${selectedDataPoint.actualData[1]}` : '_'}\n`}
+            selectedDataPoint?.actualXYZData
+              ? `${selectedDataPoint.actualXYZData[1]}` : '_'}\n`}
 
           {`(z-axis) ${selectedDataPoint?.columnZ ?? '-'}: ${
-            selectedDataPoint?.actualData
-              ? `${selectedDataPoint.actualData[2]}` : '_'}\n`}
+            selectedDataPoint?.actualXYZData
+              ? `${selectedDataPoint.actualXYZData[2]}` : '_'}\n`}
 
         </Text>
       </Plane>

--- a/my-webxr-app/src/components/GraphingDataPointMenu.tsx
+++ b/my-webxr-app/src/components/GraphingDataPointMenu.tsx
@@ -52,24 +52,23 @@ export default function GraphingDataPointMenu(
         <meshBasicMaterial color="gray" />
         {/* A negative depth offset brings the object closer to the viewer */}
         <Text fontSize={0.075} color="black" depthOffset={-4}>
-          {`Here are data point # ${selectedDataPoint?.id ?? '-'} properties!\n\n`}
+          {`Data point #${selectedDataPoint?.id ?? '-'} properties!\n\n`}
           {WriteHook(`| ${String(selectedDataPoint?.id)} : `)}
-          {`Marker: ${selectedDataPoint?.marker ?? '-'}\n`}
-          {WriteHook(`${String(selectedDataPoint?.marker)} : `)}
           {`Color: ${selectedDataPoint?.color ?? '-'}\n`}
           {WriteHook(`${String(selectedDataPoint?.color)} : `)}
-          {`x, y, z: ${
+
+          {`(x-axis) ${selectedDataPoint?.columnX ?? '-'}: ${
             selectedDataPoint?.actualData
-              ? `${selectedDataPoint.actualData[0]}, ${selectedDataPoint.actualData[1]}, ${selectedDataPoint.actualData[2]}`
-              : '0, 0, 0'
-          }\n`}
-          {WriteHook(`${String(selectedDataPoint?.actualData)} : `)}
-          {`Column X: ${selectedDataPoint?.columnX ?? '-'}\n`}
-          {WriteHook(`${String(selectedDataPoint?.columnX)} : `)}
-          {`Column Y: ${selectedDataPoint?.columnY ?? '-'}\n`}
-          {WriteHook(`${String(selectedDataPoint?.columnY)} : `)}
-          {`Column Z: ${selectedDataPoint?.columnZ ?? '-'}`}
-          {WriteHook(`${String(selectedDataPoint?.columnZ)} |`)}
+              ? `${selectedDataPoint.actualData[0]}` : '_'}\n`}
+
+          {`(y-axis) ${selectedDataPoint?.columnY ?? '-'}: ${
+            selectedDataPoint?.actualData
+              ? `${selectedDataPoint.actualData[1]}` : '_'}\n`}
+
+          {`(z-axis) ${selectedDataPoint?.columnZ ?? '-'}: ${
+            selectedDataPoint?.actualData
+              ? `${selectedDataPoint.actualData[2]}` : '_'}\n`}
+
         </Text>
       </Plane>
     </Billboard>

--- a/my-webxr-app/src/components/GraphingDataPointMenu.tsx
+++ b/my-webxr-app/src/components/GraphingDataPointMenu.tsx
@@ -9,13 +9,20 @@ import WriteHook from '../../smoketests/TestHookWrite';
 import { DataPointProps } from '../types/DataPointTypes';
 
 /**
- * Creates a billboard to display the related information of the data point
- * @pre-condition None
- * @post-condition a billboard to display the related information of the data point
- * @param {JSX.IntrinsicAttributes & Omit<BillboardProps,
- *      "ref"> & React.RefAttributes<Group>} billboardProps Props to provide to the Billboard
- *      element
- * @return {JSX.Element} a billboard to display the related information of the data point
+ * Creates a billboard to display the related information of a data point in a 3D graph.
+ * The billboard is visible when a data point is selected and displays properties of the data point.
+ *
+ * @param {JSX.IntrinsicAttributes &
+ * Omit<BillboardProps, "ref"> & React.RefAttributes<Group>} billboardProps
+ * Props to provide to the Billboard element. These props control the appearance and behavior of the
+ * billboard.
+ *
+ * @pre-condition A data point must be selected for the billboard to be visible.
+ * @post-condition A billboard is returned that displays the properties of the selected data point.
+ *
+ * @return {JSX.Element} A billboard that displays the properties of the selected data point.
+ * If no data point is selected, the billboard is not visible.
+ *
  * @constructor
  */
 export default function GraphingDataPointMenu(
@@ -48,27 +55,37 @@ export default function GraphingDataPointMenu(
 
   return (
     <Billboard visible={selectedDataPoint != null} {...billboardProps}>
-      <Plane args={[1.25, 0.8]}>
+      <Plane args={[1.25, 1.5]}>
         <meshBasicMaterial color="gray" />
         {/* A negative depth offset brings the object closer to the viewer */}
         <Text fontSize={0.075} color="black" depthOffset={-4}>
           {`Data point #${selectedDataPoint?.id ?? '-'} properties!\n\n`}
           {WriteHook(`| ${String(selectedDataPoint?.id)} : `)}
-          {`Color: ${selectedDataPoint?.color ?? '-'}\n`}
+          {`[Color]    ${selectedDataPoint?.color ?? '-'}\n`}
           {WriteHook(`${String(selectedDataPoint?.color)} : `)}
 
-          {`(x-axis) ${selectedDataPoint?.columnX ?? '-'}: ${
+          {`[X axis]    ${selectedDataPoint?.columnX ?? '-'}: ${
             selectedDataPoint?.actualXYZData
               ? `${selectedDataPoint.actualXYZData[0]}` : '_'}\n`}
 
-          {`(y-axis) ${selectedDataPoint?.columnY ?? '-'}: ${
+          {`[Y axis]    ${selectedDataPoint?.columnY ?? '-'}: ${
             selectedDataPoint?.actualXYZData
               ? `${selectedDataPoint.actualXYZData[1]}` : '_'}\n`}
 
-          {`(z-axis) ${selectedDataPoint?.columnZ ?? '-'}: ${
+          {`[Z axis]    ${selectedDataPoint?.columnZ ?? '-'}: ${
             selectedDataPoint?.actualXYZData
               ? `${selectedDataPoint.actualXYZData[2]}` : '_'}\n`}
 
+          {// Display optional column values if any of them are selected
+  selectedDataPoint?.optionalColumns && selectedDataPoint?.optionalColumnData
+  && (() => {
+    let result = '';
+    for (let i = 0; i < selectedDataPoint.optionalColumns.length; i += 1) {
+      result += `[Col ${i + 1} ]    ${selectedDataPoint.optionalColumns[i]}: ${selectedDataPoint.optionalColumnData[i]}\n`;
+    }
+    return result;
+  })()
+}
         </Text>
       </Plane>
     </Billboard>

--- a/my-webxr-app/src/components/SelectAxesMenu.tsx
+++ b/my-webxr-app/src/components/SelectAxesMenu.tsx
@@ -17,7 +17,8 @@ interface DropDownProps {
 }
 
 /*
-  this function creates the dropdowns that will be used to choose the axes for XYZ
+  this function creates the dropdowns that will be used to choose a column for the x,y,z axes or
+  the optional columns
   @param label: the label of the dropdown (the text beside it)
   @param id: the id of the dropdown (to classify x, y, or z)
   @param options: this will be the choices that can fill the dropdowns
@@ -55,7 +56,7 @@ function DropDown({
 }
 
 /*
-  this function will allow the user to choose their axis values
+  this function will allow the user to choose their axis columns and optional columns
   @param dbName: the name of the database to get the data from
   @pre-condition: dB name cannot be empty, relies on database
   @post-condition: setting the proper x,y,z coordinates for the data point
@@ -64,10 +65,28 @@ function DropDown({
 export default function SelectAxesColumns({ reload, database }: SelectAxesColumnsProps) {
   assert(database != null, 'Database name cannot be null');
   const [AxisOptions, setAxisOptions] = useState<{ value: string; label: string }[]>([]);
-  const { setSelectedXAxis, setSelectedYAxis, setSelectedZAxis } = useAxesSelectionContext();
+  const {
+    setSelectedXAxis,
+    setSelectedYAxis,
+    setSelectedZAxis,
+    setSelectedOptionalColumn1,
+    setSelectedOptionalColumn2,
+    setSelectedOptionalColumn3,
+    setSelectedOptionalColumn4,
+    setSelectedOptionalColumn5,
+    setSelectedOptionalColumn6,
+    setSelectedOptionalColumn7,
+  } = useAxesSelectionContext();
   const [xAxis, setXAxis] = useState('');
   const [yAxis, setYAxis] = useState('');
   const [zAxis, setZAxis] = useState('');
+  const [optionalColumn1, setOptionalColumn1] = useState('');
+  const [optionalColumn2, setOptionalColumn2] = useState('');
+  const [optionalColumn3, setOptionalColumn3] = useState('');
+  const [optionalColumn4, setOptionalColumn4] = useState('');
+  const [optionalColumn5, setOptionalColumn5] = useState('');
+  const [optionalColumn6, setOptionalColumn6] = useState('');
+  const [optionalColumn7, setOptionalColumn7] = useState('');
 
   useEffect(() => {
     async function fetchColumnTitles() {
@@ -100,11 +119,25 @@ export default function SelectAxesColumns({ reload, database }: SelectAxesColumn
     _setSelectedXAxis: React.Dispatch<React.SetStateAction<string | null>>,
     _setSelectedYAxis: React.Dispatch<React.SetStateAction<string | null>>,
     _setSelectedZAxis: React.Dispatch<React.SetStateAction<string | null>>,
+    _setSelectedOptionalColumn1: React.Dispatch<React.SetStateAction<string | null>>,
+    _setSelectedOptionalColumn2: React.Dispatch<React.SetStateAction<string | null>>,
+    _setSelectedOptionalColumn3: React.Dispatch<React.SetStateAction<string | null>>,
+    _setSelectedOptionalColumn4: React.Dispatch<React.SetStateAction<string | null>>,
+    _setSelectedOptionalColumn5: React.Dispatch<React.SetStateAction<string | null>>,
+    _setSelectedOptionalColumn6: React.Dispatch<React.SetStateAction<string | null>>,
+    _setSelectedOptionalColumn7: React.Dispatch<React.SetStateAction<string | null>>,
   ) => {
     try {
       _setSelectedXAxis(xAxis);
       _setSelectedYAxis(yAxis);
       _setSelectedZAxis(zAxis);
+      _setSelectedOptionalColumn1(optionalColumn1);
+      _setSelectedOptionalColumn2(optionalColumn2);
+      _setSelectedOptionalColumn3(optionalColumn3);
+      _setSelectedOptionalColumn4(optionalColumn4);
+      _setSelectedOptionalColumn5(optionalColumn5);
+      _setSelectedOptionalColumn6(optionalColumn6);
+      _setSelectedOptionalColumn7(optionalColumn7);
       WriteHook('Complete Selection button clicked : ');
     } catch (error) {
       // eslint-disable-next-line no-console
@@ -117,10 +150,66 @@ export default function SelectAxesColumns({ reload, database }: SelectAxesColumn
       <DropDown label="Select X Axis: " id="xAxis" options={AxisOptions} chosenValue={setXAxis} />
       <DropDown label="Select Y Axis: " id="yAxis" options={AxisOptions} chosenValue={setYAxis} />
       <DropDown label="Select Z Axis: " id="zAxis" options={AxisOptions} chosenValue={setZAxis} />
+      <br />
+      <br />
+      <DropDown
+        label="Optional Col 1: "
+        id="optionalColumn1"
+        options={AxisOptions}
+        chosenValue={setOptionalColumn1}
+      />
+      <DropDown
+        label="Optional Col 2: "
+        id="optionalColumn2"
+        options={AxisOptions}
+        chosenValue={setOptionalColumn2}
+      />
+      <DropDown
+        label="Optional Col 3: "
+        id="optionalColumn3"
+        options={AxisOptions}
+        chosenValue={setOptionalColumn3}
+      />
+      <DropDown
+        label="Optional Col 4: "
+        id="optionalColumn4"
+        options={AxisOptions}
+        chosenValue={setOptionalColumn4}
+      />
+      <DropDown
+        label="Optional Col 5: "
+        id="optionalColumn5"
+        options={AxisOptions}
+        chosenValue={setOptionalColumn5}
+      />
+      <DropDown
+        label="Optional Col 6: "
+        id="optionalColumn6"
+        options={AxisOptions}
+        chosenValue={setOptionalColumn6}
+      />
+      <DropDown
+        label="Optional Col 7: "
+        id="optionalColumn7"
+        options={AxisOptions}
+        chosenValue={setOptionalColumn7}
+      />
+      <br />
       <button
         type="submit"
         onClick={() => {
-          handleCompleteSelection(setSelectedXAxis, setSelectedYAxis, setSelectedZAxis);
+          handleCompleteSelection(
+            setSelectedXAxis,
+            setSelectedYAxis,
+            setSelectedZAxis,
+            setSelectedOptionalColumn1,
+            setSelectedOptionalColumn2,
+            setSelectedOptionalColumn3,
+            setSelectedOptionalColumn4,
+            setSelectedOptionalColumn5,
+            setSelectedOptionalColumn6,
+            setSelectedOptionalColumn7,
+          );
         }}
       >
         Complete Selection

--- a/my-webxr-app/src/contexts/AxesSelectionContext.tsx
+++ b/my-webxr-app/src/contexts/AxesSelectionContext.tsx
@@ -31,6 +31,35 @@ interface AxesSelectionContextType {
   setSelectedZAxis: React.Dispatch<
   React.SetStateAction<AxesSelectionContextType['selectedZAxis']>
   >;
+
+  selectedOptionalColumn1: string | null;
+  setSelectedOptionalColumn1: React.Dispatch<
+  React.SetStateAction<AxesSelectionContextType['selectedOptionalColumn1']>
+  >;
+  selectedOptionalColumn2: string | null;
+  setSelectedOptionalColumn2: React.Dispatch<
+  React.SetStateAction<AxesSelectionContextType['selectedOptionalColumn2']>
+  >;
+  selectedOptionalColumn3: string | null;
+  setSelectedOptionalColumn3: React.Dispatch<
+  React.SetStateAction<AxesSelectionContextType['selectedOptionalColumn3']>
+  >;
+  selectedOptionalColumn4: string | null;
+  setSelectedOptionalColumn4: React.Dispatch<
+  React.SetStateAction<AxesSelectionContextType['selectedOptionalColumn4']>
+  >;
+  selectedOptionalColumn5: string | null;
+  setSelectedOptionalColumn5: React.Dispatch<
+  React.SetStateAction<AxesSelectionContextType['selectedOptionalColumn5']>
+  >;
+  selectedOptionalColumn6: string | null;
+  setSelectedOptionalColumn6: React.Dispatch<
+  React.SetStateAction<AxesSelectionContextType['selectedOptionalColumn6']>
+  >;
+  selectedOptionalColumn7: string | null;
+  setSelectedOptionalColumn7: React.Dispatch<
+  React.SetStateAction<AxesSelectionContextType['selectedOptionalColumn7']>
+  >;
 }
 
 /**
@@ -53,9 +82,27 @@ export function AxesSelectionProvider({
   children,
 }: React.PropsWithChildren) {
   /* Create the internal selected axis State */
-  const [selectedXAxis, setSelectedXAxisInternal] = useState<AxesSelectionContextType['selectedXAxis']>(null);
-  const [selectedYAxis, setSelectedYAxisInternal] = useState<AxesSelectionContextType['selectedYAxis']>(null);
-  const [selectedZAxis, setSelectedZAxisInternal] = useState<AxesSelectionContextType['selectedZAxis']>(null);
+  const [selectedXAxis, setSelectedXAxisInternal] = useState<
+  AxesSelectionContextType['selectedXAxis']>(null);
+  const [selectedYAxis, setSelectedYAxisInternal] = useState<
+  AxesSelectionContextType['selectedYAxis']>(null);
+  const [selectedZAxis, setSelectedZAxisInternal] = useState<
+  AxesSelectionContextType['selectedZAxis']>(null);
+  const [selectedOptionalColumn1, setSelectedOptionalColumn1Internal] = useState<
+  AxesSelectionContextType['selectedOptionalColumn1']>(null);
+  const [selectedOptionalColumn2, setSelectedOptionalColumn2Internal] = useState<
+  AxesSelectionContextType['selectedOptionalColumn2']>(null);
+  const [selectedOptionalColumn3, setSelectedOptionalColumn3Internal] = useState<
+  AxesSelectionContextType['selectedOptionalColumn3']>(null);
+  const [selectedOptionalColumn4, setSelectedOptionalColumn4Internal] = useState<
+  AxesSelectionContextType['selectedOptionalColumn4']>(null);
+  const [selectedOptionalColumn5, setSelectedOptionalColumn5Internal] = useState<
+  AxesSelectionContextType['selectedOptionalColumn5']>(null);
+  const [selectedOptionalColumn6, setSelectedOptionalColumn6Internal] = useState<
+  AxesSelectionContextType['selectedOptionalColumn6']>(null);
+  const [selectedOptionalColumn7, setSelectedOptionalColumn7Internal] = useState<
+  AxesSelectionContextType['selectedOptionalColumn7']>(null);
+
   const rollbar = useRollbar();
 
   const setSelectedXAxis = (
@@ -79,6 +126,55 @@ export function AxesSelectionProvider({
     setSelectedZAxisInternal(newValue);
   };
 
+  const setSelectedOptionalColumn1 = (
+    newValue: React.SetStateAction<string | null>,
+  ) => {
+    rollbar.debug(`AxesSelectionContext: updating selectedOptionalColumn1 state to ${newValue}`);
+    setSelectedOptionalColumn1Internal(newValue);
+  };
+
+  const setSelectedOptionalColumn2 = (
+    newValue: React.SetStateAction<string | null>,
+  ) => {
+    rollbar.debug(`AxesSelectionContext: updating selectedOptionalColumn2 state to ${newValue}`);
+    setSelectedOptionalColumn2Internal(newValue);
+  };
+
+  const setSelectedOptionalColumn3 = (
+    newValue: React.SetStateAction<string | null>,
+  ) => {
+    rollbar.debug(`AxesSelectionContext: updating selectedOptionalColumn3 state to ${newValue}`);
+    setSelectedOptionalColumn3Internal(newValue);
+  };
+
+  const setSelectedOptionalColumn4 = (
+    newValue: React.SetStateAction<string | null>,
+  ) => {
+    rollbar.debug(`AxesSelectionContext: updating selectedOptionalColumn4 state to ${newValue}`);
+    setSelectedOptionalColumn4Internal(newValue);
+  };
+
+  const setSelectedOptionalColumn5 = (
+    newValue: React.SetStateAction<string | null>,
+  ) => {
+    rollbar.debug(`AxesSelectionContext: updating selectedOptionalColumn5 state to ${newValue}`);
+    setSelectedOptionalColumn5Internal(newValue);
+  };
+
+  const setSelectedOptionalColumn6 = (
+    newValue: React.SetStateAction<string | null>,
+  ) => {
+    rollbar.debug(`AxesSelectionContext: updating selectedOptionalColumn6 state to ${newValue}`);
+    setSelectedOptionalColumn6Internal(newValue);
+  };
+
+  const setSelectedOptionalColumn7 = (
+    newValue: React.SetStateAction<string | null>,
+  ) => {
+    rollbar.debug(`AxesSelectionContext: updating selectedOptionalColumn7 state to ${newValue}`);
+    setSelectedOptionalColumn7Internal(newValue);
+  };
+
   /* Cache the value to prevent unnecessary re-renders. */
   const value = useMemo(
     () => ({
@@ -88,8 +184,33 @@ export function AxesSelectionProvider({
       setSelectedYAxis,
       selectedZAxis,
       setSelectedZAxis,
+      selectedOptionalColumn1,
+      setSelectedOptionalColumn1,
+      selectedOptionalColumn2,
+      setSelectedOptionalColumn2,
+      selectedOptionalColumn3,
+      setSelectedOptionalColumn3,
+      selectedOptionalColumn4,
+      setSelectedOptionalColumn4,
+      selectedOptionalColumn5,
+      setSelectedOptionalColumn5,
+      selectedOptionalColumn6,
+      setSelectedOptionalColumn6,
+      selectedOptionalColumn7,
+      setSelectedOptionalColumn7,
     }),
-    [selectedXAxis, selectedYAxis, selectedZAxis],
+    [
+      selectedXAxis,
+      selectedYAxis,
+      selectedZAxis,
+      selectedOptionalColumn1,
+      selectedOptionalColumn2,
+      selectedOptionalColumn3,
+      selectedOptionalColumn4,
+      selectedOptionalColumn5,
+      selectedOptionalColumn6,
+      selectedOptionalColumn7,
+    ],
   );
 
   return (

--- a/my-webxr-app/src/data/DataAbstractor.tsx
+++ b/my-webxr-app/src/data/DataAbstractor.tsx
@@ -17,6 +17,13 @@ export default interface DataAbstractor {
     columnX: string,
     ColumnY: string,
     ColumnZ: string,
+    OptionalColumn1?: string,
+    OptionalColumn2?: string,
+    OptionalColumn3?: string,
+    OptionalColumn4?: string,
+    OptionalColumn5?: string,
+    OptionalColumn6?: string,
+    OptionalColumn7?: string,
   ) => Promise<[Array<DataPoint>, Array<number>]>,
   resetFlag: () => Promise<boolean>;
   storeStandardizedData:() => Promise<boolean>;

--- a/my-webxr-app/src/data/DataLayer.tsx
+++ b/my-webxr-app/src/data/DataLayer.tsx
@@ -433,6 +433,20 @@ export default class DataLayer implements DataAbstractor {
    * @param {string | null} columnX - The name of the column to be used for the x-axis values.
    * @param {string | null} ColumnY - The name of the column to be used for the y-axis values.
    * @param {string | null} ColumnZ - The name of the column to be used for the z-axis values.
+   * @param {string | undefined} OptionalColumn1 - Optional column name to have value display in
+   * data point menu
+   * @param {string | undefined} OptionalColumn2 - Optional column name to have value display in
+   * data point menu
+   * @param {string | undefined} OptionalColumn3 - Optional column name to have value display in
+   * data point menu
+   * @param {string | undefined} OptionalColumn4 - Optional column name to have value display in
+   * data point menu
+   * @param {string | undefined} OptionalColumn5 - Optional column name to have value display in
+   * data point menu
+   * @param {string | undefined} OptionalColumn6 - Optional column name to have value display in
+   * data point menu
+   * @param {string | undefined} OptionalColumn7 - Optional column name to have value display in
+   * data point menu
    * @returns {Promise<[Array<DataPoint>, Array<number>]>} A promise that resolves to an array of
    * DataPoint objects and an array of maximum values from each column.
    * Each DataPoint object represents a point in a 3D space with x, y, and z coordinates.
@@ -441,8 +455,26 @@ export default class DataLayer implements DataAbstractor {
     columnX: string,
     ColumnY: string,
     ColumnZ: string,
+    OptionalColumn1?: string,
+    OptionalColumn2?: string,
+    OptionalColumn3?: string,
+    OptionalColumn4?: string,
+    OptionalColumn5?: string,
+    OptionalColumn6?: string,
+    OptionalColumn7?: string,
   ): Promise<[Array<DataPoint>, Array<number>]> {
-    return this.repository.getPoints(columnX, ColumnY, ColumnZ);
+    return this.repository.getPoints(
+      columnX,
+      ColumnY,
+      ColumnZ,
+      OptionalColumn1,
+      OptionalColumn2,
+      OptionalColumn3,
+      OptionalColumn4,
+      OptionalColumn5,
+      OptionalColumn6,
+      OptionalColumn7,
+    );
   }
 
   /**

--- a/my-webxr-app/src/repository/DataPoint.tsx
+++ b/my-webxr-app/src/repository/DataPoint.tsx
@@ -5,23 +5,29 @@ export default class DataPoint {
 
   zValue: number;
 
+  optionalColumnValues?: number[];
+
   /**
    * Represents a 3-dimensional data point abstraction
    *
-   * @param {number} xValue A value associated with the x axis to be displayed.
-   * @param {number} yValue A value associated with the y axis to be displayed.
-   * @param {number} zValue A value associated with the z axis to be displayed.
-   * @pre-condition hasMissingData correctly declares whether any of the values are undefined and
-   *      xValue, yValue, zValue are all numbers, strings, or undefined
+   * @param {number} xValue A value associated with the x-axis to be displayed.
+   * @param {number} yValue A value associated with the y-axis to be displayed.
+   * @param {number} zValue A value associated with the z-axis to be displayed.
+   * @param {number[]} optionalColumnValues An array of optional column values to be displayed in
+   * data point menu.
+   * @pre-condition xValue, yValue, zValue are all numbers and optionalColumnValues is an array of
+   * numbers or undefined
    * @post-condition The returned object defined element-wise operations on the data set
    */
   constructor(
     xValue: number,
     yValue: number,
     zValue: number,
+    optionalColumnValues?: number[],
   ) {
     this.xValue = xValue;
     this.yValue = yValue;
     this.zValue = zValue;
+    this.optionalColumnValues = optionalColumnValues;
   }
 }

--- a/my-webxr-app/src/repository/DataPoint.tsx
+++ b/my-webxr-app/src/repository/DataPoint.tsx
@@ -5,7 +5,19 @@ export default class DataPoint {
 
   zValue: number;
 
-  optionalColumnValues?: number[];
+  optionalCol1Value? : number;
+
+  optionalCol2Value? : number;
+
+  optionalCol3Value? : number;
+
+  optionalCol4Value? : number;
+
+  optionalCol5Value? : number;
+
+  optionalCol6Value? : number;
+
+  optionalCol7Value? : number;
 
   /**
    * Represents a 3-dimensional data point abstraction
@@ -13,7 +25,13 @@ export default class DataPoint {
    * @param {number} xValue A value associated with the x-axis to be displayed.
    * @param {number} yValue A value associated with the y-axis to be displayed.
    * @param {number} zValue A value associated with the z-axis to be displayed.
-   * @param {number[]} optionalColumnValues An array of optional column values to be displayed in
+   * @param optionalCol1Value A value associated with the first optional column to be displayed.
+   * @param optionalCol2Value A value associated with the second optional column to be displayed.
+   * @param optionalCol3Value A value associated with the third optional column to be displayed.
+   * @param optionalCol4Value A value associated with the fourth optional column to be displayed.
+   * @param optionalCol5Value A value associated with the fifth optional column to be displayed.
+   * @param optionalCol6Value A value associated with the sixth optional column to be displayed.
+   * @param optionalCol7Value A value associated with the seventh optional column to be displayed.
    * data point menu.
    * @pre-condition xValue, yValue, zValue are all numbers and optionalColumnValues is an array of
    * numbers or undefined
@@ -23,11 +41,23 @@ export default class DataPoint {
     xValue: number,
     yValue: number,
     zValue: number,
-    optionalColumnValues?: number[],
+    optionalCol1Value? : number,
+    optionalCol2Value? : number,
+    optionalCol3Value? : number,
+    optionalCol4Value? : number,
+    optionalCol5Value? : number,
+    optionalCol6Value? : number,
+    optionalCol7Value? : number,
   ) {
     this.xValue = xValue;
     this.yValue = yValue;
     this.zValue = zValue;
-    this.optionalColumnValues = optionalColumnValues;
+    this.optionalCol1Value = optionalCol1Value;
+    this.optionalCol2Value = optionalCol2Value;
+    this.optionalCol3Value = optionalCol3Value;
+    this.optionalCol4Value = optionalCol4Value;
+    this.optionalCol5Value = optionalCol5Value;
+    this.optionalCol6Value = optionalCol6Value;
+    this.optionalCol7Value = optionalCol7Value;
   }
 }

--- a/my-webxr-app/src/repository/Repository.tsx
+++ b/my-webxr-app/src/repository/Repository.tsx
@@ -11,6 +11,13 @@ export interface Repository {
     columnXName: string,
     columnYName: string,
     columnZName: string,
+    optionalColumn1Name?: string,
+    optionalColumn2Name?: string,
+    optionalColumn3Name?: string,
+    optionalColumn4Name?: string,
+    optionalColumn5Name?: string,
+    optionalColumn6Name?: string,
+    optionalColumn7Name?: string,
   ) => Promise<[Array<DataPoint>, Array<number>]>;
   addColumn: (column: Column<RawColumn | StatsColumn | NumericColumn>,
     columnType: TableName) => Promise<string>;

--- a/my-webxr-app/src/types/DataPointTypes.tsx
+++ b/my-webxr-app/src/types/DataPointTypes.tsx
@@ -9,9 +9,11 @@ export interface DataPointProps {
   columnX: string;
   columnY: string;
   columnZ: string;
+  optionalColumns?: string[];
   color: string
   marker: string
-  actualData?: number[];
+  actualXYZData?: number[];
+  optionalColumnData?: number[];
   outlineScale?: number;
   size?: OctahedronGeometryProps['args'];
   meshProps?: JSX.IntrinsicElements['mesh'];

--- a/my-webxr-app/src/types/DataPointTypes.tsx
+++ b/my-webxr-app/src/types/DataPointTypes.tsx
@@ -12,8 +12,8 @@ export interface DataPointProps {
   optionalColumns?: string[];
   color: string
   marker: string
-  actualXYZData?: number[];
-  optionalColumnData?: number[];
+  actualXYZData?: Array<number | undefined>;
+  optionalColumnData?: Array<string>;
   outlineScale?: number;
   size?: OctahedronGeometryProps['args'];
   meshProps?: JSX.IntrinsicElements['mesh'];

--- a/my-webxr-app/src/utils/CsvUtils.tsx
+++ b/my-webxr-app/src/utils/CsvUtils.tsx
@@ -83,7 +83,7 @@ async function parseAndHandleUrlCsv(
         setMessage('Url CSV loaded successfully');
         await DAL.calculateStatistics();
         await DAL.storeStandardizedData();
-        await DAL.storePCA(await DAL.getAvailableFields());
+        // await DAL.storePCA(await DAL.getAvailableFields());
         resolve('success');
       },
       error: (error) => {

--- a/my-webxr-app/tests/components/CreateGraphingDataPoints.test.tsx
+++ b/my-webxr-app/tests/components/CreateGraphingDataPoints.test.tsx
@@ -68,6 +68,20 @@ describe('createGraphingDataPoints', () => {
       setSelectedYAxis: vi.fn(),
       selectedZAxis: 'colZ',
       setSelectedZAxis: vi.fn(),
+      selectedOptionalColumn1: '',
+      setSelectedOptionalColumn1: vi.fn(),
+      selectedOptionalColumn2: '',
+      setSelectedOptionalColumn2: vi.fn(),
+      selectedOptionalColumn3: '',
+      setSelectedOptionalColumn3: vi.fn(),
+      selectedOptionalColumn4: '',
+      setSelectedOptionalColumn4: vi.fn(),
+      selectedOptionalColumn5: '',
+      setSelectedOptionalColumn5: vi.fn(),
+      selectedOptionalColumn6: '',
+      setSelectedOptionalColumn6: vi.fn(),
+      selectedOptionalColumn7: '',
+      setSelectedOptionalColumn7: vi.fn(),
     });
 
     const render = await ReactThreeTestRenderer.create(

--- a/my-webxr-app/tests/components/CreatePointPositions.test.tsx
+++ b/my-webxr-app/tests/components/CreatePointPositions.test.tsx
@@ -66,7 +66,7 @@ describe("Datapoint's Location is based off of values given ", () => {
       <Provider config={rollbarConfig}>
         <PointSelectionProvider>
           <XR>
-            <GraphingDataPoint id={0} marker="circle" color="gray" columnX="John Doe" columnY="cmpt 145" columnZ="97" actualData={[1, 2, 3]} meshProps={{ position: [1, 2, 3] }} />
+            <GraphingDataPoint id={0} marker="circle" color="gray" columnX="John Doe" columnY="cmpt 145" columnZ="97" actualXYZData={[1, 2, 3]} meshProps={{ position: [1, 2, 3] }} />
           </XR>
         </PointSelectionProvider>
       </Provider>,
@@ -82,7 +82,7 @@ describe("Datapoint's Location is based off of values given ", () => {
       <Provider config={rollbarConfig}>
         <PointSelectionProvider>
           <XR>
-            <GraphingDataPoint id={4} marker="circle" color="gray" columnX="John Doe" columnY="cmpt 145" columnZ="97" actualData={exampleData[0]} meshProps={{ position: datapoint1 }} />
+            <GraphingDataPoint id={4} marker="circle" color="gray" columnX="John Doe" columnY="cmpt 145" columnZ="97" actualXYZData={exampleData[0]} meshProps={{ position: datapoint1 }} />
           </XR>
         </PointSelectionProvider>
       </Provider>,
@@ -98,7 +98,7 @@ describe("Datapoint's Location is based off of values given ", () => {
       <Provider config={rollbarConfig}>
         <PointSelectionProvider>
           <XR>
-            <GraphingDataPoint id={4} marker="circle" color="gray" columnX="John Doe" columnY="cmpt 145" columnZ="97" actualData={exampleData[1]} meshProps={{ position: datapoint2 }} />
+            <GraphingDataPoint id={4} marker="circle" color="gray" columnX="John Doe" columnY="cmpt 145" columnZ="97" actualXYZData={exampleData[1]} meshProps={{ position: datapoint2 }} />
           </XR>
         </PointSelectionProvider>
       </Provider>,
@@ -113,7 +113,7 @@ describe("Datapoint's Location is based off of values given ", () => {
       <Provider config={rollbarConfig}>
         <PointSelectionProvider>
           <XR>
-            <GraphingDataPoint id={4} marker="circle" color="gray" columnX="John Doe" columnY="cmpt 145" columnZ="97" actualData={exampleData[2]} meshProps={{ position: datapoint3 }} />
+            <GraphingDataPoint id={4} marker="circle" color="gray" columnX="John Doe" columnY="cmpt 145" columnZ="97" actualXYZData={exampleData[2]} meshProps={{ position: datapoint3 }} />
           </XR>
         </PointSelectionProvider>
       </Provider>,
@@ -128,7 +128,7 @@ describe("Datapoint's Location is based off of values given ", () => {
       <Provider config={rollbarConfig}>
         <PointSelectionProvider>
           <XR>
-            <GraphingDataPoint id={4} marker="circle" color="gray" columnX="John Doe" columnY="cmpt 145" columnZ="97" actualData={exampleData[3]} meshProps={{ position: datapoint4 }} />
+            <GraphingDataPoint id={4} marker="circle" color="gray" columnX="John Doe" columnY="cmpt 145" columnZ="97" actualXYZData={exampleData[3]} meshProps={{ position: datapoint4 }} />
           </XR>
         </PointSelectionProvider>
       </Provider>,
@@ -144,7 +144,7 @@ describe("Datapoint's Location is based off of values given ", () => {
       <Provider config={rollbarConfig}>
         <PointSelectionProvider>
           <XR>
-            <GraphingDataPoint id={4} marker="circle" color="gray" columnX="John Doe" columnY="cmpt 145" columnZ="97" actualData={exampleData[4]} meshProps={{ position: datapoint5 }} />
+            <GraphingDataPoint id={4} marker="circle" color="gray" columnX="John Doe" columnY="cmpt 145" columnZ="97" actualXYZData={exampleData[4]} meshProps={{ position: datapoint5 }} />
           </XR>
         </PointSelectionProvider>
       </Provider>,

--- a/my-webxr-app/tests/components/GenerateXYZ.test.tsx
+++ b/my-webxr-app/tests/components/GenerateXYZ.test.tsx
@@ -1,6 +1,7 @@
 import ReactThreeTestRenderer from '@react-three/test-renderer';
 import { XR } from '@react-three/xr';
-import { ReactThreeTestInstance } from '@react-three/test-renderer/dist/declarations/src/createTestInstance';
+import { ReactThreeTestInstance } from
+  '@react-three/test-renderer/dist/declarations/src/createTestInstance';
 import { expect } from 'vitest';
 import Dexie from 'dexie';
 import { Provider } from '@rollbar/react';
@@ -30,6 +31,20 @@ describe('Generate XYZ axes', () => {
       setSelectedYAxis: vi.fn(),
       selectedZAxis: 'colZ',
       setSelectedZAxis: vi.fn(),
+      selectedOptionalColumn1: '',
+      setSelectedOptionalColumn1: vi.fn(),
+      selectedOptionalColumn2: '',
+      setSelectedOptionalColumn2: vi.fn(),
+      selectedOptionalColumn3: '',
+      setSelectedOptionalColumn3: vi.fn(),
+      selectedOptionalColumn4: '',
+      setSelectedOptionalColumn4: vi.fn(),
+      selectedOptionalColumn5: '',
+      setSelectedOptionalColumn5: vi.fn(),
+      selectedOptionalColumn6: '',
+      setSelectedOptionalColumn6: vi.fn(),
+      selectedOptionalColumn7: '',
+      setSelectedOptionalColumn7: vi.fn(),
     });
   });
 

--- a/my-webxr-app/tests/components/SelectAxesMenu.test.tsx
+++ b/my-webxr-app/tests/components/SelectAxesMenu.test.tsx
@@ -42,17 +42,19 @@ describe('SelectAxesColumns Component Tests', () => {
 
     // check that the dropdowns and options are rendered
     const dropdowns = await queryAllByRole('combobox');
-    expect(dropdowns).toHaveLength(3);
+    // 3 axes + 7 optional columns
+    expect(dropdowns).toHaveLength(10);
 
     const options = await queryAllByRole('option');
-    expect(options).toHaveLength(12);
+    // 4 options each field x 10 fields = 40 options
+    expect(options).toHaveLength(40);
 
     const selectOptions = await queryAllByText('Select an option');
-    expect(selectOptions).toHaveLength(3);
+    expect(selectOptions).toHaveLength(10);
 
     ['field1', 'field2', 'field3'].forEach((field) => {
       const fieldOptions = queryAllByText(field);
-      expect(fieldOptions).toHaveLength(3);
+      expect(fieldOptions).toHaveLength(10);
     });
   });
 });

--- a/my-webxr-app/tests/components/SelectAxesMenu.test.tsx
+++ b/my-webxr-app/tests/components/SelectAxesMenu.test.tsx
@@ -42,7 +42,8 @@ describe('SelectAxesColumns Component Tests', () => {
 
     // check that the dropdowns and options are rendered
     const dropdowns = await queryAllByRole('combobox');
-    expect(dropdowns).toHaveLength(3);
+    // 3 axes + 7 optional columns
+    expect(dropdowns).toHaveLength(10);
 
     const options = await queryAllByRole('option');
     expect(options).toHaveLength(12);


### PR DESCRIPTION
Closes #275 

# What was the issue
- Having another 7 optional column selections. 
- When selected, those optional column values will be displayed on the data point menu.

# What was done and why
- Refactor Repository & DAL to query an array of data points having up to 10 values per data point (3 values for x,y,z and 7 optional values for those selected columns)
- Update the selection menu to have an extra 7 selection fields.
- Modify the data point menu to display newly added data point properties

# How it was tested
- Modify old unit tests
- Visual verification in VR using [TestDataMenu.csv](https://github.com/UniversityOfSaskatchewanCMPT371/term-project-2024-team-2/files/14954564/TestDataMenu.csv).

![image](https://github.com/UniversityOfSaskatchewanCMPT371/term-project-2024-team-2/assets/94843824/10d94004-ed6b-4783-a6cd-bd77099184c6)




